### PR TITLE
Added method for waiting textbox field to be editable

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/controls/textbox.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/textbox.py
@@ -54,7 +54,7 @@ class TextBox(BaseControl):
         '''
         return self.input.get_attribute('type').strip()
 
-    def wait_for_field_to_be_editable(self):
+    def wait_to_be_editable(self):
         """
         Wait for the textbox field to be editable
         """


### PR DESCRIPTION
As a part of this PR, the following has been implemented:

- Added **wait_for_field_to_be_editable** method, which waits for the textbox field to become editable.
