### PR TITLE
Enhanced Learn-more link. Added context for better troubleshooting

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/controls/learn_more.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/learn_more.py
@@ -19,7 +19,7 @@ class LearnMore(BaseControl):
         super(LearnMore, self).__init__(browser, container)
 
     @contextmanager
-    def go_to_link(self):
+    def open_link(self):
         '''
         Redirects the browser object to the link provided by the container and returns the URL
         '''


### PR DESCRIPTION
The tests should be updated once this PR is merged. Example, 

```
        account = AccountPage(ucc_smartx_configs)
        go_to_link = "https://docs.splunk.com/Documentation"
        account.entity.open()
        with account.entity.help_link.open_link() as link_url:
            self.assert_util(
                    account.entity.help_link.get_current_url,
                    go_to_link
                    )

```