### PR TITLE
Ignore ssl warnings in firefox (saucelabs)

### DIFF
--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -190,7 +190,9 @@ class SeleniumHelper(object):
             'platformName': 'Windows 10',
             'browserName': 'firefox',
             'browserVersion': browser_version,
-            'sauce:options': self.get_sauce_opts()
+            'sauce:options': self.get_sauce_opts(),
+            'acceptInsecureCerts': True,
+            'acceptSslCerts': True
         }
         return firefox_opts
 


### PR DESCRIPTION
To ignore the SSL Warning in Firefox with Saucelabs