### PR TITLE
ci: Updated image to node12 in release stage.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:11
+      - image: circleci/node:12
     steps:
       - checkout
       - run: npx semantic-release


### PR DESCRIPTION
latest version of semantic-release is broken on node11 image.