### PR TITLE
fix: updated delete_btn to waitspinner for delete TC

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/table.py
+++ b/pytest_splunk_addon_ui_smartx/components/table.py
@@ -289,7 +289,7 @@ class Table(BaseComponent):
                 return self.get_clear_text(self.delete_prompt)  
             else:
                 self.delete_btn.click()
-                self.wait_until("delete_btn")
+                self.wait_until("waitspinner")
             
     def set_filter(self, filter_query):
         """


### PR DESCRIPTION
Updated table.py's delete_row() function.
"delete_btn" to "waitspinner"