### PR TITLE
downgrade semantic-release version to resume release stage as latest version is having some issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
       - image: circleci/node:12
     steps:
       - checkout
-      - run: npx semantic-release
+      - run: npx semantic-release@16.0.0
 
   publish-pypi:
     docker:


### PR DESCRIPTION
The release stage failed due to buggy version of semantic-release in the this CI run : https://app.circleci.com/pipelines/github/splunk/addon-factory-smartx-ui-test-library/514/workflows/7916e20e-3721-45d1-8fd6-c3029058209d