### PR TITLE
INFRA-33660 Fixing UI element for Alert Actions dropdown element

### DIFF
--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/account_select.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/account_select.py
@@ -13,8 +13,8 @@ class AlertAccountSelect(ActionControls):
         super(AlertAccountSelect, self).__init__(browser, container)
         self.elements.update({
             "internal_container": Selector(select=container.select + " .splunk-dropdown"),
-            "dropdown": Selector(select=container.select + ' button[data-is-menu="true"]'),
-            "selected": Selector(select=container.select + ' button[data-is-menu="true"] span[data-test="label"]'),
+            "dropdown": Selector(select=container.select + ' button[label="Select..."]'),
+            "selected": Selector(select=container.select + ' button[type="button"] span[data-test="label"]'),
             "values": Selector(select='div[data-test="popover"] button[data-test="option"]'),
             "cancel_selected": Selector(select=container.select + ' button[data-icon-only="true"]')
         })


### PR DESCRIPTION
Changing the selector for the Alert Actions Select Account dropdown, as the old selector is stale and is no longer able to find the element. 