### PR TITLE
INFRA-33748-troubleshoot-failures-on-NOAH-SHC Alert Actions fix

### DIFF
--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/account_select.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/account_select.py
@@ -16,7 +16,7 @@ class AlertAccountSelect(ActionControls):
             "dropdown": Selector(select=container.select + ' button[label="Select..."]'),
             "selected": Selector(select=container.select + ' button[type="button"] span[data-test="label"]'),
             "values": Selector(select='div[data-test="popover"] button[data-test="option"]'),
-            "cancel_selected": Selector(select=container.select + ' button[data-icon-only="true"]')
+            "cancel_selected": Selector(select=container.select + ' button[data-test="button"]')
         })
 
     def wait_for_values(self):


### PR DESCRIPTION
* Fixing cancel_selected selector for Alert Actions dropdown by updating the selector to something more uniform between differing Splunk versions including Olympus builds. 
