### PR TITLE
fix: selnium grid covered input cant be clicked

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,11 @@ commands:
             mkdir output 
             cd output
             pwd
-            curl -s https://api.github.com/repos/splunk/splunk-add-on-for-ucc-example/releases/latest | grep "Splunk_TA.*tar.gz" | grep -v search_head | grep -v indexer | grep -v forwarder | cut -d : -f 2,3 | tr -d \" | wget -qi - || true
+            curl -s https://api.github.com/repos/splunk/splunk-add-on-for-ucc-example/releases/latest | grep "Splunk_TA.*.spl" | grep -v search_head | grep -v indexer | grep -v forwarder | cut -d : -f 2,3 | tr -d \" | wget -qi - || true
             ls
-            tar -xzf *.tar.gz
+            tar -xzf *.spl
             ls
-            rm *.tar.gz
+            rm *.spl
             ls
       - run:
           name: Setup for testing

--- a/pytest_splunk_addon_ui_smartx/components/controls/multi_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/multi_select.py
@@ -7,13 +7,15 @@ from ..base_component import Selector
 from .base_control import BaseControl
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.common.exceptions import ElementClickInterceptedException
+
 
 class MultiSelect(BaseControl):
     """
     Entity-Component: Multiselect
 
     Select Javascript framework: select2
-    
+
     A dropdown which can select more than one values
     """
     def __init__(self, browser, container):
@@ -59,7 +61,11 @@ class MultiSelect(BaseControl):
         """
         try:
             time.sleep(1)
-            self.input.click()
+            try:
+                self.input.click()
+            except ElementClickInterceptedException:
+                self.label_text.click()
+                self.input.click()
             time.sleep(1)
             popoverid = '#' + self.dropdown.get_attribute("data-test-popover-id")
 


### PR DESCRIPTION
fix for issue where element can't be clicked because it's covered by expanded list. The solution is to click on field's label to close the list