### PR TITLE
ci: update semantic version and remove node 14 workaround

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,15 @@
-# SPDX-FileCopyrightText: 2020 Splunk Inc.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 version: 2
 updates:
-  # Keep package.json (& lockfiles) up to date as soon as
-  # new versions are published to the npm registry
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "daily"
-  # Keep Dockerfile up to date, batching pull requests weekly
   - package-ecosystem: "pip"
     directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
     schedule:
       interval: "daily"

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -316,13 +316,10 @@ jobs:
           python-version: "3.7"
       - name: Install Poetry
         run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2.5.4
+        uses: cycjimmy/semantic-release-action@v3.0.0
         with:
-          semantic_version: 17
+          semantic_version: 19.0.2
           extra_plugins: |
             @semantic-release/exec
             @semantic-release/git


### PR DESCRIPTION
- ci: update semantic version and remove node 14 workaround
- ci: add dependabot conf for github-actions
