### PR TITLE
test: use SPLUNK_DISABLE_POPUPS=true and remove workaround

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -54,6 +54,7 @@ services:
       - SPLUNK_PASSWORD=Chang3d!
       - SPLUNK_START_ARGS=--accept-license
       - SPLUNK_HEC_TOKEN=9b741d03-43e9-4164-908b-e09102327d22
+      - SPLUNK_DISABLE_POPUPS=true
 
   sauceconnect:
     build:

--- a/tests/ui/test_splunk_ta_example_addon_alert_actions.py
+++ b/tests/ui/test_splunk_ta_example_addon_alert_actions.py
@@ -1,52 +1,7 @@
 import pytest
 from pytest_splunk_addon_ui_smartx.base_test import UccTester
-from pytest_splunk_addon_ui_smartx.components.base_component import Selector
-from pytest_splunk_addon_ui_smartx.components.controls.button import Button
 
 from .Example_UccLib.alert_action import AlertPage
-
-
-@pytest.fixture(autouse=True)
-def setup_alert(ucc_smartx_selenium_helper):
-    """
-    Skip the popups in Splunk before executing the tests
-    """
-    try:
-        # Splunk 8.x
-        if not setup_alert.first_execution:
-            return
-
-        AlertPage(ucc_smartx_selenium_helper, None, open_page=False)
-        intro_popup = Button(
-            ucc_smartx_selenium_helper.browser,
-            Selector(select=".modal-footer .btn-save"),
-        )
-        intro_popup.wait_to_be_clickable()
-        intro_popup.click()
-        setup_alert.first_execution = False
-
-        # Splunk 8.2.x
-        intro_popup = Button(
-            ucc_smartx_selenium_helper.browser,
-            Selector(select='[data-test="label"]'),
-        )
-        intro_popup.wait_to_be_clickable()
-        intro_popup.click()
-
-        # Splunk 8.0.x
-        important_changes_coming = Button(
-            ucc_smartx_selenium_helper.browser,
-            Selector(
-                select='div[data-test-name="python3-notification-modal"] button[data-test="button"][data-appearance="secondary"]'
-            ),
-        )
-        important_changes_coming.wait_to_be_clickable()
-        important_changes_coming.click()
-    except Exception:
-        pass
-
-
-setup_alert.first_execution = True
 
 
 @pytest.fixture


### PR DESCRIPTION
Using `SPLUNK_DISABLE_POPUPS` env variable to control popups, setting it to `true` so we don't need to have workaround code to bypass those.

Check out docs here: https://github.com/splunk/splunk-ansible/blob/186c95b84d82f9201e036388c716d466d083ae37/docs/ADVANCED.md?plain=1#L101