### PR TITLE
fix: increase default timeout for the browser

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/base_component.py
+++ b/pytest_splunk_addon_ui_smartx/components/base_component.py
@@ -24,7 +24,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-DEFAULT_TIMEOUT = 20
+DEFAULT_TIMEOUT = 30
 
 
 class ActionChains(action_chains):


### PR DESCRIPTION
It is a temporary solution before we decommission Saucelabs.