### PR TITLE
ci: run 8 parallel UI test jobs

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -129,6 +129,7 @@ jobs:
       checks: write
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
         browser: ["chrome", "firefox"]


### PR DESCRIPTION
This way the tests should be more stable.