### PR TITLE
fix: remove enterprise cloud ToS code for login page

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/login.py
+++ b/pytest_splunk_addon_ui_smartx/components/login.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-import time
-
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 
@@ -41,8 +38,6 @@ class Login(BaseComponent):
             "username": Selector(by=By.ID, select="username"),
             "password": Selector(by=By.ID, select="password"),
             "homepage": Selector(select='a[data-action="home"]'),
-            "accept_checkbox": Selector(by=By.ID, select="accept"),
-            "accept_button": Selector(select=" .accept-tos-button.btn.btn-primary"),
         }
 
     def login(self, username, password):
@@ -51,19 +46,7 @@ class Login(BaseComponent):
             :param username: Str the username for the splunk instance we want to access
             :param password: Str the password for the splunk instance we want to access
         """
-
-        global ENTERPRISE_CLOUD_ToS
-
         self.username.send_keys(username)
         self.password.send_keys(password)
         self.password.send_keys("\ue007")
-        try:
-            if ENTERPRISE_CLOUD_ToS:
-                ENTERPRISE_CLOUD_ToS = False
-                self.wait_to_be_clickable("accept_checkbox")
-                self.accept_checkbox.click()
-                self.wait_for("accept_button")
-                self.accept_button.click()
-        except TimeoutException:
-            pass
         self.wait_for("homepage", "Could not log in to the Splunk instance.")


### PR DESCRIPTION
We wait for some time every time when we login, but that ToS is not there. This should speed up the test execution especially in the case of not persisting browser.