### PR TITLE
fix: ADDON-66912 SingleSelect is_editable fix and add SingleSelect allow_new_values

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -348,9 +348,22 @@ class SingleSelect(BaseControl):
             _wait_for_search_list, msg="No values found in SingleSelect search"
         )
 
+    def allow_new_values(self) -> bool:
+        """
+        Returns True if the SingleSelect accepts new values, False otherwise
+        """
+        self.get_element("root")
+        return True if self.allow_new_values else False
+
     def is_editable(self) -> bool:
         """
         Returns True if the SingleSelect is editable, False otherwise
         """
-        self.get_element("root")
-        return True if self.allow_new_values else False
+        if (
+            self.root.get_attribute("readonly")
+            or self.root.get_attribute("readOnly")
+            or self.root.get_attribute("disabled")
+        ):
+            return False
+        else:
+            return True

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -193,3 +193,6 @@ class Dropdown(BaseComponent):
             }
         )
         return [each.text.strip() for each in self.get_elements("type_filter_list")]
+
+    def wait_to_be_stale(self, msg=None):
+        return super().wait_to_be_stale(key=self.get_element("root"), msg=msg)

--- a/tests/testdata/Splunk_TA_UCCExample/globalConfig.json
+++ b/tests/testdata/Splunk_TA_UCCExample/globalConfig.json
@@ -626,7 +626,8 @@
                             "type": "singleSelect",
                             "label": "Example Account",
                             "options": {
-                                "referenceName": "account"
+                                "referenceName": "account",
+                                "disableonEdit": true
                             },
                             "help": "",
                             "field": "account",
@@ -965,7 +966,10 @@
                 {
                     "groupName": "group_one",
                     "groupTitle": "Group One",
-                    "groupServices": ["example_input_three", "example_input_four"]
+                    "groupServices": [
+                        "example_input_three",
+                        "example_input_four"
+                    ]
                 }
             ],
             "description": "Manage your data inputs",

--- a/tests/ui/test_splunk_ta_example_addon_input_1.py
+++ b/tests/ui/test_splunk_ta_example_addon_input_1.py
@@ -880,14 +880,12 @@ class TestInput(UccTester):
         """Verifies the frontend edit functionality of the example input one entity"""
         input_page = InputPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
         input_page.table.edit_row("dummy_input_one")
-        input_page.entity1.example_account.wait_for_values()
         input_page.entity1.example_checkbox.uncheck()
         input_page.entity1.example_radio.select("No")
         input_page.entity1.single_select_group_test.select("four")
         input_page.entity1.multiple_select_test.deselect("b")
         input_page.entity1.interval.set_value("3600")
         input_page.entity1.index.select("main")
-        input_page.entity1.example_account.select("test_input")
         input_page.entity1.object.set_value("edit_object")
         input_page.entity1.object_fields.set_value("edit_field")
         input_page.entity1.order_by.set_value("LastDate")
@@ -918,14 +916,12 @@ class TestInput(UccTester):
         """Verifies the backend edit functionality of the example input one entity"""
         input_page = InputPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
         input_page.table.edit_row("dummy_input_one")
-        input_page.entity1.example_account.wait_for_values()
         input_page.entity1.example_checkbox.uncheck()
         input_page.entity1.example_radio.select("No")
         input_page.entity1.single_select_group_test.select("Four")
         input_page.entity1.multiple_select_test.deselect("b")
         input_page.entity1.interval.set_value("3600")
         input_page.entity1.index.select("main")
-        input_page.entity1.example_account.select("test_input")
         input_page.entity1.object.set_value("edit_object")
         input_page.entity1.object_fields.set_value("edit_field")
         input_page.entity1.order_by.set_value("LastDate")
@@ -1355,7 +1351,7 @@ class TestInput(UccTester):
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.forwarder
     @pytest.mark.input
-    def test_single_select_is_editable(
+    def test_single_select_allows_new_values(
         self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
     ):
         """
@@ -1363,6 +1359,22 @@ class TestInput(UccTester):
         """
         input_page = InputPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
         input_page.create_new_input.select("Example Input One")
-        self.assert_util(input_page.entity1.single_select_group_test.is_editable, True)
-        self.assert_util(input_page.entity1.index.is_editable, True)
+        self.assert_util(
+            input_page.entity1.single_select_group_test.allow_new_values, True
+        )
+        self.assert_util(input_page.entity1.index.allow_new_values, True)
+        self.assert_util(input_page.entity1.example_account.allow_new_values, False)
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.forwarder
+    @pytest.mark.input
+    def test_single_select_is_editable(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper, add_input_one
+    ):
+        """
+        Verifies that SingleSelect value is editable or not
+        """
+        input_page = InputPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        input_page.table.edit_row("dummy_input_one")
         self.assert_util(input_page.entity1.example_account.is_editable, False)
+        self.assert_util(input_page.entity1.index.is_editable, True)

--- a/tests/ui/test_splunk_ta_example_addon_input_common.py
+++ b/tests/ui/test_splunk_ta_example_addon_input_common.py
@@ -368,6 +368,7 @@ class TestInput(UccTester):
             "Example Input Four",
         ]
         input_page.create_new_input.select("Group One")
+        input_page.create_new_input.wait_to_be_stale()
         self.assert_util(input_page.create_new_input.get_inputs_list, value_to_test)
 
     @pytest.mark.execute_enterprise_cloud_true


### PR DESCRIPTION
The same as in #412.

- Fix SingleSelect is_editable() checking if field can be modified on edit
- Add SingleSelect allow_new_values() checking if field accepts custom values
- add corresponding UI tests
- override BaseComponents wait_to_be_stale() in Dropdown and add to flaky tests to resolve a Stale Element Error

Reference:

* https://splunk.atlassian.net/browse/ADDON-66912
* https://splunk.atlassian.net/browse/ADDON-65416

Released as beta and tested:

* https://github.com/splunk/splunk-add-on-for-amazon-web-services/pull/1126
* https://github.com/splunk/splunk-add-on-for-okta-identity-cloud/pull/231