### PR TITLE
feat: selenium standalone for UI testing

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,17 @@ ReadTheDocs Page link: https://addon-factory-smartx-ui-test-library.readthedocs.
 
 ## Table of contents
 
-- [Goal](#goal)
-- [Design](#design)
-- [Features](#features)
-- [Build test cases using the framework](#build-test-cases-using-the-framework)
-- [Steps to test in Local environment](#steps-to-test-in-local-environment)
-- [Steps to test with Saucelabs](#steps-to-test-with-saucelabs)
+- [SPDX-FileCopyrightText: 2020 Splunk Inc.](#spdx-filecopyrighttext-2020-splunk-inc)
+- [](#)
+- [SPDX-License-Identifier: Apache-2.0](#spdx-license-identifier-apache-20)
+- [SmartX](#smartx)
+  - [Table of contents](#table-of-contents)
+    - [Goal](#goal)
+    - [Design](#design)
+    - [Features](#features)
+    - [Build test cases using the framework](#build-test-cases-using-the-framework)
+    - [Steps to test in Local environment](#steps-to-test-in-local-environment)
+    - [Steps to test with Saucelabs](#steps-to-test-with-saucelabs)
  
 ### Goal
 
@@ -75,7 +80,7 @@ https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver#required-conf
 2. Configure saucelabs credentials as environment variables
     SAUCE_USERNAME : <saucelabs_username>
     SAUCE_PASSWORD : <saucelabs_access_key>
-3. Execute the test cases
+3. Execute the test case
 ```script
 pytest -vv --browser={browser} --splunk-host={web_url} --splunk-port={mgmt_url} --setup-retry-count={retry-count} --splunk-user {username} --splunk-password {password}
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2020 Splunk Inc.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 # SmartX
 
 UCC based Add-on UI automation framework 
@@ -12,18 +8,13 @@ ReadTheDocs Page link: https://addon-factory-smartx-ui-test-library.readthedocs.
 
 ## Table of contents
 
-- [SPDX-FileCopyrightText: 2020 Splunk Inc.](#spdx-filecopyrighttext-2020-splunk-inc)
-- [](#)
-- [SPDX-License-Identifier: Apache-2.0](#spdx-license-identifier-apache-20)
-- [SmartX](#smartx)
-  - [Table of contents](#table-of-contents)
-    - [Goal](#goal)
-    - [Design](#design)
-    - [Features](#features)
-    - [Build test cases using the framework](#build-test-cases-using-the-framework)
-    - [Steps to test in Local environment](#steps-to-test-in-local-environment)
-    - [Steps to test with Saucelabs](#steps-to-test-with-saucelabs)
- 
+- [Goal](#goal)
+- [Design](#design)
+- [Features](#features)
+- [Build test cases using the framework](#build-test-cases-using-the-framework)
+- [Steps to test in Local environment](#steps-to-test-in-local-environment)
+- [Steps to test with Saucelabs](#steps-to-test-with-saucelabs)
+
 ### Goal
 
 To test all the UI configuration page of the Splunk add-ons. All the add-ons are built with the same template. The configuration pages consist of an Input page and a configuration page that has different tabs to configure logging, proxy settings and add product account in the add-ons. To support the testing of all the add-ons, a generic framework should be made, which can be used in the test cases for all the add-ons. The framework should have methods that can interact with UI components and test the working of UI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/__init__.py
+++ b/pytest_splunk_addon_ui_smartx/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/__init__.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/__init__.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/__init__.py
@@ -75,4 +75,5 @@ class AlertEntity(Entity):
         """
         Open the required page. Page(super) class opens the page by default.
         """
+        self.add_alert.wait_to_be_clickable()
         self.add_alert.click()

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/__init__.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/account_select.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/account_select.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/action_controls.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/action_controls.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/alert_base_component.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/alert_base_component.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/alert_base_control.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/alert_base_control.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/button.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/button.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
@@ -44,7 +44,7 @@ class AlertCheckbox(ActionControls):
         for _ in range(max_attempts):
             try:
                 self.wait_to_be_clickable("checkbox")
-                self.checkbox_btn.click()
+                self.checkbox.click()
                 after_toggle = self.is_checked()
                 if before_toggle != after_toggle:
                     return

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
@@ -44,7 +44,7 @@ class AlertCheckbox(ActionControls):
         for _ in range(max_attempts):
             try:
                 self.wait_to_be_clickable("checkbox")
-                self.checkbox.click()
+                self.checkbox_btn.click()
                 after_toggle = self.is_checked()
                 if before_toggle != after_toggle:
                     return

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
@@ -51,7 +51,6 @@ class AlertCheckbox(ActionControls):
                 time.sleep(0.25)
             except Exception as e:
                 print(f"Toggle checkbox failed with {e}")
-        raise Exception("Toggle operation failed!")
 
     def check(self):
         """
@@ -61,9 +60,11 @@ class AlertCheckbox(ActionControls):
         try:
             if self.is_checked() == False:
                 self.toggle()
-            return True
-        except:
-            return "Checkbox is already checked"
+                return True
+            else:
+                return "Checkbox is already checked"
+        except Exception as e:
+            print(f"Check checkbox failed with {e}")
 
     def uncheck(self):
         """
@@ -73,9 +74,11 @@ class AlertCheckbox(ActionControls):
         try:
             if self.is_checked() == True:
                 self.toggle()
-            return True
-        except:
-            return "Checkbox is already unchecked"
+                return True
+            else:
+                return "Checkbox is already unchecked"
+        except Exception as e:
+            print(f"Uncheck checkbox failed with {e}")
 
     def is_checked(self):
         """

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/checkbox.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import time
 from .action_controls import ActionControls
 from .alert_base_component import Selector
 from .alert_base_control import AlertBaseControl
@@ -35,12 +36,22 @@ class AlertCheckbox(ActionControls):
             }
         )
 
-    def toggle(self):
+    def toggle(self, max_attempts=5):
         """
         Toggles the checkbox value
         """
-        self.wait_to_be_clickable("checkbox")
-        self.checkbox.click()
+        before_toggle = self.is_checked()
+        for _ in range(max_attempts):
+            try:
+                self.wait_to_be_clickable("checkbox")
+                self.checkbox.click()
+                after_toggle = self.is_checked()
+                if before_toggle != after_toggle:
+                    return
+                time.sleep(0.25)
+            except Exception as e:
+                print(f"Toggle checkbox failed with {e}")
+        raise Exception("Toggle operation failed!")
 
     def check(self):
         """

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/dropdown.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/searchbox.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/searchbox.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/single_select.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/table.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/table.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/table.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/table.py
@@ -277,10 +277,12 @@ class AlertTable(ActionControls):
 
             self.wait_for("delete_prompt")
             if cancel:
+                self.wait_to_be_clickable("delete_cancel")
                 self.delete_cancel.click()
                 self.wait_until("delete_cancel")
                 return True
             elif close:
+                self.wait_to_be_clickable("delete_close")
                 self.delete_close.click()
                 self.wait_until("delete_close")
                 return True
@@ -288,6 +290,7 @@ class AlertTable(ActionControls):
                 self.wait_for_text("delete_prompt")
                 return self.get_clear_text(self.delete_prompt)
             else:
+                self.wait_to_be_clickable("delete_btn")
                 self.delete_btn.click()
                 self.wait_for("app_listings")
 

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/textbox.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/textbox.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/textbox.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/textbox.py
@@ -37,6 +37,7 @@ class AlertTextBox(ActionControls):
         """
         set value of the textbox
         """
+        self.wait_to_be_clickable("input")
         self.input.clear()
         self.input.send_keys(value)
 

--- a/pytest_splunk_addon_ui_smartx/alert_actions/components/toggle.py
+++ b/pytest_splunk_addon_ui_smartx/alert_actions/components/toggle.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/backend_confs.py
+++ b/pytest_splunk_addon_ui_smartx/backend_confs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -69,7 +69,7 @@ class SeleniumHelper:
         self.test_case = test_case
         self.skip_saucelab_job = False
         
-        selenium_dns = os.environ.get('SELENIUM_DNS', '')
+        selenium_dns = os.environ.get('SELENIUM_HOST', '')
 
         if "grid" in browser:
             self.skip_saucelab_job = True

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -68,8 +68,8 @@ class SeleniumHelper:
         self.cred = cred
         self.test_case = test_case
         self.skip_saucelab_job = False
-        
-        selenium_host = os.environ.get('SELENIUM_HOST', '')
+
+        selenium_host = os.environ.get("SELENIUM_HOST", "")
 
         if "grid" in browser:
             self.skip_saucelab_job = True
@@ -86,13 +86,13 @@ class SeleniumHelper:
                     )
                 elif selenium_host:
                     options_firefox = webdriver.FirefoxOptions()
-                    options_firefox.add_argument('--ignore-ssl-errors=yes')
-                    options_firefox.add_argument('--ignore-certificate-errors')
-                    options_firefox.add_argument('--disable-dev-shm-usage')
-                    
+                    options_firefox.add_argument("--ignore-ssl-errors=yes")
+                    options_firefox.add_argument("--ignore-certificate-errors")
+                    options_firefox.add_argument("--disable-dev-shm-usage")
+
                     self.browser = webdriver.Remote(
                         command_executor=f"{selenium_host}:4444/wd/hub",
-                        options=options_firefox
+                        options=options_firefox,
                     )
                     self.browser.implicitly_wait(3)
                 elif saucelabs:
@@ -111,13 +111,13 @@ class SeleniumHelper:
                     )
                 elif selenium_host:
                     options_chrome = webdriver.ChromeOptions()
-                    options_chrome.add_argument('--ignore-ssl-errors=yes')
-                    options_chrome.add_argument('--ignore-certificate-errors')
-                    options_chrome.add_argument('--disable-dev-shm-usage')
+                    options_chrome.add_argument("--ignore-ssl-errors=yes")
+                    options_chrome.add_argument("--ignore-certificate-errors")
+                    options_chrome.add_argument("--disable-dev-shm-usage")
 
                     self.browser = webdriver.Remote(
                         command_executor=f"{selenium_host}:4444/wd/hub",
-                        options=options_chrome
+                        options=options_chrome,
                     )
                     self.browser.implicitly_wait(3)
                 elif saucelabs:

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -67,20 +67,15 @@ class SeleniumHelper:
         self.cred = cred
         self.test_case = test_case
         self.skip_saucelab_job = False
+        
+        selenium_dns = os.environ.get('SELENIUM_DNS', '')
 
         if "grid" in browser:
             self.skip_saucelab_job = True
             debug = True
-        options_chrome = webdriver.ChromeOptions()
-        options_chrome.add_argument('--ignore-ssl-errors=yes')
-        options_chrome.add_argument('--ignore-certificate-errors')
-        options_chrome.add_argument('--disable-dev-shm-usage')
-        options_firefox = webdriver.FirefoxOptions()
-        options_firefox.add_argument('--ignore-ssl-errors=yes')
-        options_firefox.add_argument('--ignore-certificate-errors')
-        options_firefox.add_argument('--disable-dev-shm-usage')
+        elif selenium_dns:
+            self.skip_saucelab_job = True
 
-        selenium_dns = os.environ.get('SELENIUM_DNS', '')
         try:
             if browser == "firefox":
                 if debug:
@@ -88,10 +83,22 @@ class SeleniumHelper:
                         firefox_options=self.get_local_firefox_opts(headless),
                         log_path="selenium.log",
                     )
-                else:
+                elif selenium_dns:
+                    options_firefox = webdriver.FirefoxOptions()
+                    options_firefox.add_argument('--ignore-ssl-errors=yes')
+                    options_firefox.add_argument('--ignore-certificate-errors')
+                    options_firefox.add_argument('--disable-dev-shm-usage')
+                    
                     self.browser = webdriver.Remote(
                         command_executor=f"{selenium_dns}:4444/wd/hub",
                         options=options_firefox
+                    )
+                else:
+                    self.browser = webdriver.Remote(
+                        command_executor="https://ondemand.saucelabs.com:443/wd/hub",
+                        desired_capabilities=self.get_sauce_firefox_opts(
+                            browser_version
+                        ),
                     )
 
             elif browser == "chrome":
@@ -100,10 +107,22 @@ class SeleniumHelper:
                         chrome_options=self.get_local_chrome_opts(headless),
                         service_args=["--verbose", "--log-path=selenium.log"],
                     )
-                else:
+                elif selenium_dns:
+                    options_chrome = webdriver.ChromeOptions()
+                    options_chrome.add_argument('--ignore-ssl-errors=yes')
+                    options_chrome.add_argument('--ignore-certificate-errors')
+                    options_chrome.add_argument('--disable-dev-shm-usage')
+
                     self.browser = webdriver.Remote(
                         command_executor=f"{selenium_dns}:4444/wd/hub",
                         options=options_chrome
+                    )
+                else:
+                    self.browser = webdriver.Remote(
+                        command_executor="https://ondemand.saucelabs.com:443/wd/hub",
+                        desired_capabilities=self.get_sauce_chrome_opts(
+                            browser_version
+                        ),
                     )
 
             # selenium local stack

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -60,7 +60,6 @@ class SeleniumHelper:
         debug=False,
         cred=("admin", "Chang3d!"),
         headless=False,
-        saucelabs=False,
         test_case=None,
     ):
         self.splunk_web_url = splunk_web_url
@@ -76,8 +75,9 @@ class SeleniumHelper:
             debug = True
         elif selenium_host:
             self.skip_saucelab_job = True
-        if not debug or not selenium_host:
-            # Using Saucelabs
+        if debug or selenium_host:
+            pass
+        else:
             self.init_sauce_env_variables()
 
         try:

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -84,6 +84,7 @@ class SeleniumHelper:
         options = webdriver.ChromeOptions()
         options.add_argument('--ignore-ssl-errors=yes')
         options.add_argument('--ignore-certificate-errors')
+        options.add_argument('--disable-dev-shm-usage')
             
         try:
             if browser == "firefox":
@@ -106,7 +107,7 @@ class SeleniumHelper:
                     )
                 else:
                     self.browser = webdriver.Remote(
-                        command_executor=f"{self.selenium_dns}:4444/wd/hub",
+                        command_executor=f"http://localhost:4444/wd/hub",
                         options=options
                     )
 

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -318,12 +318,14 @@ class SeleniumHelper:
         if headless_run:
             chrome_opts.add_argument("--headless")
             chrome_opts.add_argument("--window-size=1280,768")
+            chrome_opts.add_argument("--disable-dev-shm-usage")
         return chrome_opts
 
     def get_local_firefox_opts(self, headless_run):
         firefox_opts = webdriver.FirefoxOptions()
         firefox_opts.add_argument("--ignore-ssl-errors=yes")
         firefox_opts.add_argument("--ignore-certificate-errors")
+        firefox_opts.add_argument("--disable-dev-shm-usage")
         firefox_opts.log.level = "trace"
         if headless_run:
             firefox_opts.add_argument("--headless")

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -71,11 +71,14 @@ class SeleniumHelper:
         if "grid" in browser:
             self.skip_saucelab_job = True
             debug = True
-
+        # options = webdriver.ChromeOptions()
+        # options.add_argument('--ignore-ssl-errors=yes')
+        # options.add_argument('--ignore-certificate-errors')
+        # options.add_argument('--disable-dev-shm-usage')
         if not debug:
             # Using Saucelabs
             self.init_sauce_env_variables()
-
+            
         try:
             if browser == "firefox":
                 if debug:

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -315,10 +315,10 @@ class SeleniumHelper:
         chrome_opts = webdriver.ChromeOptions()
         chrome_opts.add_argument("--ignore-ssl-errors=yes")
         chrome_opts.add_argument("--ignore-certificate-errors")
+        chrome_opts.add_argument("--disable-dev-shm-usage")
         if headless_run:
             chrome_opts.add_argument("--headless")
             chrome_opts.add_argument("--window-size=1280,768")
-            chrome_opts.add_argument("--disable-dev-shm-usage")
         return chrome_opts
 
     def get_local_firefox_opts(self, headless_run):

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -94,6 +94,7 @@ class SeleniumHelper:
                         command_executor=f"{selenium_dns}:4444/wd/hub",
                         options=options_firefox
                     )
+                    self.browser.implicitly_wait(3)
                 elif saucelabs:
                     self.browser = webdriver.Remote(
                         command_executor="https://ondemand.saucelabs.com:443/wd/hub",
@@ -118,6 +119,7 @@ class SeleniumHelper:
                         command_executor=f"{selenium_dns}:4444/wd/hub",
                         options=options_chrome
                     )
+                    self.browser.implicitly_wait(3)
                 elif saucelabs:
                     self.browser = webdriver.Remote(
                         command_executor="https://ondemand.saucelabs.com:443/wd/hub",

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -64,7 +64,6 @@ class SeleniumHelper:
     ):
         self.splunk_web_url = splunk_web_url
         self.splunk_mgmt_url = splunk_mgmt_url
-        self.selenium_dns = selenium_dns
         self.cred = cred
         self.test_case = test_case
         self.skip_saucelab_job = False

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -69,12 +69,12 @@ class SeleniumHelper:
         self.test_case = test_case
         self.skip_saucelab_job = False
         
-        selenium_dns = os.environ.get('SELENIUM_HOST', '')
+        selenium_host = os.environ.get('SELENIUM_HOST', '')
 
         if "grid" in browser:
             self.skip_saucelab_job = True
             debug = True
-        elif selenium_dns:
+        elif selenium_host:
             self.skip_saucelab_job = True
 
         try:
@@ -84,14 +84,14 @@ class SeleniumHelper:
                         firefox_options=self.get_local_firefox_opts(headless),
                         log_path="selenium.log",
                     )
-                elif selenium_dns:
+                elif selenium_host:
                     options_firefox = webdriver.FirefoxOptions()
                     options_firefox.add_argument('--ignore-ssl-errors=yes')
                     options_firefox.add_argument('--ignore-certificate-errors')
                     options_firefox.add_argument('--disable-dev-shm-usage')
                     
                     self.browser = webdriver.Remote(
-                        command_executor=f"{selenium_dns}:4444/wd/hub",
+                        command_executor=f"{selenium_host}:4444/wd/hub",
                         options=options_firefox
                     )
                     self.browser.implicitly_wait(3)
@@ -109,14 +109,14 @@ class SeleniumHelper:
                         chrome_options=self.get_local_chrome_opts(headless),
                         service_args=["--verbose", "--log-path=selenium.log"],
                     )
-                elif selenium_dns:
+                elif selenium_host:
                     options_chrome = webdriver.ChromeOptions()
                     options_chrome.add_argument('--ignore-ssl-errors=yes')
                     options_chrome.add_argument('--ignore-certificate-errors')
                     options_chrome.add_argument('--disable-dev-shm-usage')
 
                     self.browser = webdriver.Remote(
-                        command_executor=f"{selenium_dns}:4444/wd/hub",
+                        command_executor=f"{selenium_host}:4444/wd/hub",
                         options=options_chrome
                     )
                     self.browser.implicitly_wait(3)

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -69,13 +69,16 @@ class SeleniumHelper:
         self.test_case = test_case
         self.skip_saucelab_job = False
 
-        selenium_host = os.environ.get("SELENIUM_HOST", "")
+        selenium_host = os.environ.get("SELENIUM_HOST")
 
         if "grid" in browser:
             self.skip_saucelab_job = True
             debug = True
         elif selenium_host:
             self.skip_saucelab_job = True
+        if not debug or not selenium_host:
+            # Using Saucelabs
+            self.init_sauce_env_variables()
 
         try:
             if browser == "firefox":
@@ -95,7 +98,7 @@ class SeleniumHelper:
                         options=options_firefox,
                     )
                     self.browser.implicitly_wait(3)
-                elif saucelabs:
+                else:
                     self.browser = webdriver.Remote(
                         command_executor="https://ondemand.saucelabs.com:443/wd/hub",
                         desired_capabilities=self.get_sauce_firefox_opts(
@@ -120,7 +123,7 @@ class SeleniumHelper:
                         options=options_chrome,
                     )
                     self.browser.implicitly_wait(3)
-                elif saucelabs:
+                else:
                     self.browser = webdriver.Remote(
                         command_executor="https://ondemand.saucelabs.com:443/wd/hub",
                         desired_capabilities=self.get_sauce_chrome_opts(

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -73,10 +73,10 @@ class SeleniumHelper:
         if "grid" in browser:
             self.skip_saucelab_job = True
             debug = True
-        # options = webdriver.ChromeOptions()
-        # options.add_argument('--ignore-ssl-errors=yes')
-        # options.add_argument('--ignore-certificate-errors')
-        # options.add_argument('--disable-dev-shm-usage')
+        options = webdriver.ChromeOptions()
+        options.add_argument('--ignore-ssl-errors=yes')
+        options.add_argument('--ignore-certificate-errors')
+        options.add_argument('--disable-dev-shm-usage')
         #if not debug:
             # Using Saucelabs
             #self.init_sauce_env_variables()
@@ -107,7 +107,7 @@ class SeleniumHelper:
                     )
                 else:
                     self.browser = webdriver.Remote(
-                        command_executor=f"http://localhost:4444/wd/hub",
+                        command_executor=f"{self.selenium_dns}:4444/wd/hub",
                         options=options
                     )
 

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -87,7 +87,7 @@ class SeleniumHelper:
                 elif selenium_host:
                     self.browser = webdriver.Remote(
                         command_executor=f"{selenium_host}:4444/wd/hub",
-                        options=self.get_local_firefox_opts(),
+                        options=self.get_local_firefox_opts(headless_run=False),
                     )
                     self.browser.implicitly_wait(3)
                 else:
@@ -106,7 +106,7 @@ class SeleniumHelper:
                 elif selenium_host:
                     self.browser = webdriver.Remote(
                         command_executor=f"{selenium_host}:4444/wd/hub",
-                        options=self.get_local_chrome_opts(),
+                        options=self.get_local_chrome_opts(headless_run=False),
                     )
                     self.browser.implicitly_wait(3)
                 else:

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -71,10 +71,14 @@ class SeleniumHelper:
         if "grid" in browser:
             self.skip_saucelab_job = True
             debug = True
-        options = webdriver.ChromeOptions()
-        options.add_argument('--ignore-ssl-errors=yes')
-        options.add_argument('--ignore-certificate-errors')
-        options.add_argument('--disable-dev-shm-usage')
+        options_chrome = webdriver.ChromeOptions()
+        options_chrome.add_argument('--ignore-ssl-errors=yes')
+        options_chrome.add_argument('--ignore-certificate-errors')
+        options_chrome.add_argument('--disable-dev-shm-usage')
+        options_firefox = webdriver.FirefoxOptions()
+        options_firefox.add_argument('--ignore-ssl-errors=yes')
+        options_firefox.add_argument('--ignore-certificate-errors')
+        options_firefox.add_argument('--disable-dev-shm-usage')
 
         selenium_dns = os.environ.get('SELENIUM_DNS', '')
         try:
@@ -87,7 +91,7 @@ class SeleniumHelper:
                 else:
                     self.browser = webdriver.Remote(
                         command_executor=f"{selenium_dns}:4444/wd/hub",
-                        options=options
+                        options=options_firefox
                     )
 
             elif browser == "chrome":
@@ -99,7 +103,7 @@ class SeleniumHelper:
                 else:
                     self.browser = webdriver.Remote(
                         command_executor=f"{selenium_dns}:4444/wd/hub",
-                        options=options
+                        options=options_chrome
                     )
 
             # selenium local stack

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -57,6 +57,7 @@ class SeleniumHelper:
         browser_version,
         splunk_web_url,
         splunk_mgmt_url,
+        selenium_dns,
         debug=False,
         cred=("admin", "Chang3d!"),
         headless=False,
@@ -64,6 +65,7 @@ class SeleniumHelper:
     ):
         self.splunk_web_url = splunk_web_url
         self.splunk_mgmt_url = splunk_mgmt_url
+        self.selenium_dns = selenium_dns
         self.cred = cred
         self.test_case = test_case
         self.skip_saucelab_job = False
@@ -75,9 +77,13 @@ class SeleniumHelper:
         # options.add_argument('--ignore-ssl-errors=yes')
         # options.add_argument('--ignore-certificate-errors')
         # options.add_argument('--disable-dev-shm-usage')
-        if not debug:
+        #if not debug:
             # Using Saucelabs
-            self.init_sauce_env_variables()
+            #self.init_sauce_env_variables()
+        
+        options = webdriver.ChromeOptions()
+        options.add_argument('--ignore-ssl-errors=yes')
+        options.add_argument('--ignore-certificate-errors')
             
         try:
             if browser == "firefox":
@@ -88,10 +94,8 @@ class SeleniumHelper:
                     )
                 else:
                     self.browser = webdriver.Remote(
-                        command_executor="https://ondemand.saucelabs.com:443/wd/hub",
-                        desired_capabilities=self.get_sauce_firefox_opts(
-                            browser_version
-                        ),
+                        command_executor=f"{self.selenium_dns}:4444/wd/hub",
+                        options=options
                     )
 
             elif browser == "chrome":
@@ -102,10 +106,8 @@ class SeleniumHelper:
                     )
                 else:
                     self.browser = webdriver.Remote(
-                        command_executor="https://ondemand.saucelabs.com:443/wd/hub",
-                        desired_capabilities=self.get_sauce_chrome_opts(
-                            browser_version
-                        ),
+                        command_executor=f"{self.selenium_dns}:4444/wd/hub",
+                        options=options
                     )
 
             # selenium local stack

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -60,6 +60,7 @@ class SeleniumHelper:
         debug=False,
         cred=("admin", "Chang3d!"),
         headless=False,
+        saucelabs=False,
         test_case=None,
     ):
         self.splunk_web_url = splunk_web_url
@@ -93,7 +94,7 @@ class SeleniumHelper:
                         command_executor=f"{selenium_dns}:4444/wd/hub",
                         options=options_firefox
                     )
-                else:
+                elif saucelabs:
                     self.browser = webdriver.Remote(
                         command_executor="https://ondemand.saucelabs.com:443/wd/hub",
                         desired_capabilities=self.get_sauce_firefox_opts(
@@ -117,7 +118,7 @@ class SeleniumHelper:
                         command_executor=f"{selenium_dns}:4444/wd/hub",
                         options=options_chrome
                     )
-                else:
+                elif saucelabs:
                     self.browser = webdriver.Remote(
                         command_executor="https://ondemand.saucelabs.com:443/wd/hub",
                         desired_capabilities=self.get_sauce_chrome_opts(

--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -57,7 +57,6 @@ class SeleniumHelper:
         browser_version,
         splunk_web_url,
         splunk_mgmt_url,
-        selenium_dns,
         debug=False,
         cred=("admin", "Chang3d!"),
         headless=False,
@@ -77,15 +76,8 @@ class SeleniumHelper:
         options.add_argument('--ignore-ssl-errors=yes')
         options.add_argument('--ignore-certificate-errors')
         options.add_argument('--disable-dev-shm-usage')
-        #if not debug:
-            # Using Saucelabs
-            #self.init_sauce_env_variables()
-        
-        options = webdriver.ChromeOptions()
-        options.add_argument('--ignore-ssl-errors=yes')
-        options.add_argument('--ignore-certificate-errors')
-        options.add_argument('--disable-dev-shm-usage')
-            
+
+        selenium_dns = os.environ.get('SELENIUM_DNS', '')
         try:
             if browser == "firefox":
                 if debug:
@@ -95,7 +87,7 @@ class SeleniumHelper:
                     )
                 else:
                     self.browser = webdriver.Remote(
-                        command_executor=f"{self.selenium_dns}:4444/wd/hub",
+                        command_executor=f"{selenium_dns}:4444/wd/hub",
                         options=options
                     )
 
@@ -107,7 +99,7 @@ class SeleniumHelper:
                     )
                 else:
                     self.browser = webdriver.Remote(
-                        command_executor=f"{self.selenium_dns}:4444/wd/hub",
+                        command_executor=f"{selenium_dns}:4444/wd/hub",
                         options=options
                     )
 

--- a/pytest_splunk_addon_ui_smartx/components/__init__.py
+++ b/pytest_splunk_addon_ui_smartx/components/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/base_component.py
+++ b/pytest_splunk_addon_ui_smartx/components/base_component.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/conf_table.py
+++ b/pytest_splunk_addon_ui_smartx/components/conf_table.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/__init__.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/base_control.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/base_control.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/button.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/button.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/checkbox.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/checkbox.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/checkbox.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/checkbox.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import time
-
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
@@ -42,12 +40,22 @@ class Checkbox(BaseControl):
             }
         )
 
-    def toggle(self):
+    def toggle(self, max_attempts=5):
         """
         Toggles the checkbox value
         """
-        self.wait_to_be_clickable("checkbox")
-        self.checkbox_btn.click()
+        before_toggle = self.is_checked()
+        for _ in range(max_attempts):
+            try:
+                self.wait_to_be_clickable("checkbox")
+                self.checkbox.click()
+                after_toggle = self.is_checked()
+                if before_toggle != after_toggle:
+                    return
+                time.sleep(0.25)
+            except Exception as e:
+                print(f"Toggle checkbox failed with {e}")
+        raise Exception("Toggle operation failed!")
 
     def check(self):
         """

--- a/pytest_splunk_addon_ui_smartx/components/controls/checkbox.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/checkbox.py
@@ -48,7 +48,7 @@ class Checkbox(BaseControl):
         for _ in range(max_attempts):
             try:
                 self.wait_to_be_clickable("checkbox")
-                self.checkbox.click()
+                self.checkbox_btn.click()
                 after_toggle = self.is_checked()
                 if before_toggle != after_toggle:
                     return

--- a/pytest_splunk_addon_ui_smartx/components/controls/checkbox.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/checkbox.py
@@ -55,7 +55,6 @@ class Checkbox(BaseControl):
                 time.sleep(0.25)
             except Exception as e:
                 print(f"Toggle checkbox failed with {e}")
-        raise Exception("Toggle operation failed!")
 
     def check(self):
         """
@@ -65,9 +64,11 @@ class Checkbox(BaseControl):
         try:
             if self.is_checked() == False:
                 self.toggle()
-            return True
-        except:
-            return "Checkbox is already checked"
+                return True
+            else:
+                return "Checkbox is already checked"
+        except Exception as e:
+            print(f"Check checkbox failed with {e}")
 
     def uncheck(self):
         """
@@ -77,9 +78,11 @@ class Checkbox(BaseControl):
         try:
             if self.is_checked() == True:
                 self.toggle()
-            return True
-        except:
-            return "Checkbox is already unchecked"
+                return True
+            else:
+                return "Checkbox is already unchecked"
+        except Exception as e:
+            print(f"Uncheck checkbox failed with {e}")
 
     def is_checked(self):
         """

--- a/pytest_splunk_addon_ui_smartx/components/controls/learn_more.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/learn_more.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/message.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/message.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/multi_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/multi_select.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/oauth_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/oauth_select.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -18,7 +18,7 @@ from selenium.webdriver.common.keys import Keys
 
 from ..base_component import Selector
 from .base_control import BaseControl
-
+from time import sleep
 
 class SingleSelect(BaseControl):
     """
@@ -88,6 +88,7 @@ class SingleSelect(BaseControl):
         for each in self.get_elements("values"):
             if each.text.strip().lower() == value.lower():
                 each.click()
+                sleep(0.25)
                 return True
         else:
             raise ValueError("{} not found in select list".format(value))

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -102,6 +102,7 @@ class SingleSelect(BaseControl):
         """
         assert self.searchable, "Can not search, as the Singleselect is not searchable"
         if open_dropdown:
+            self.wait_to_be_clickable("root")
             self.root.click()
         if self.searchable:
             if self.allow_new_values:
@@ -138,6 +139,7 @@ class SingleSelect(BaseControl):
                     }
                 )
             else:
+                self.wait_to_be_clickable("root")
                 self.root.click()
                 popover_id = "#" + self.root.get_attribute("data-test-popover-id")
                 self.elements.update(
@@ -162,6 +164,7 @@ class SingleSelect(BaseControl):
             :return: List of the values that are visible
         """
         if open_dropdown:
+            self.wait_to_be_clickable("root")
             self.root.click()
 
         popover_id = "#" + self.root.get_attribute("data-test-popover-id")
@@ -226,6 +229,7 @@ class SingleSelect(BaseControl):
         Cancels the currently selected value in the SingleSelect
             :return: Bool whether canceling the selected item was successful, else raises an error
         """
+        self.wait_to_be_clickable("root")
         self.root.click()
         self.wait_to_be_clickable("cancel_selected")
         self.cancel_selected.click()
@@ -237,6 +241,7 @@ class SingleSelect(BaseControl):
             :return: list of options avaialble within the single select
         """
         selected_val = self.get_value()
+        self.wait_to_be_clickable("root")
         self.root.click()
         first_element = None
         list_of_values = []

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -18,7 +18,6 @@ from selenium.webdriver.common.keys import Keys
 
 from ..base_component import Selector
 from .base_control import BaseControl
-from time import sleep
 
 class SingleSelect(BaseControl):
     """

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -215,6 +215,7 @@ class SingleSelect(BaseControl):
                     }
                 )
             else:
+                self.wait_to_be_clickable("root")
                 self.root.click()
                 popover_id = "#" + self.root.get_attribute("data-test-popover-id")
                 self.elements.update(

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -70,9 +70,11 @@ class SingleSelect(BaseControl):
             :return: Bool if successful in selection, else raises an error
         """
         if open_dropdown:
+            self.wait_to_be_clickable("root")
             self.root.click()
 
         if self.allow_new_values and self.get_value():
+            self.wait_to_be_clickable("cancel_selected")
             self.cancel_selected.click()
 
         popover_id = "#" + self.root.get_attribute("data-test-popover-id")

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -365,7 +365,6 @@ class SingleSelect(BaseControl):
         """
         Returns True if the SingleSelect is editable, False otherwise
         """
-        self.wait_to_be_clickable("root")
         if (
             self.root.get_attribute("readonly")
             or self.root.get_attribute("readOnly")

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -90,7 +90,6 @@ class SingleSelect(BaseControl):
         for each in self.get_elements("values"):
             if each.text.strip().lower() == value.lower():
                 each.click()
-                sleep(1)
                 return True
         else:
             raise ValueError("{} not found in select list".format(value))

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -19,6 +19,7 @@ from selenium.webdriver.common.keys import Keys
 from ..base_component import Selector
 from .base_control import BaseControl
 
+
 class SingleSelect(BaseControl):
     """
     Entity-Component: Select, ComboBox

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -88,7 +88,7 @@ class SingleSelect(BaseControl):
         for each in self.get_elements("values"):
             if each.text.strip().lower() == value.lower():
                 each.click()
-                sleep(0.25)
+                sleep(1)
                 return True
         else:
             raise ValueError("{} not found in select list".format(value))

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -366,6 +366,7 @@ class SingleSelect(BaseControl):
         """
         Returns True if the SingleSelect is editable, False otherwise
         """
+        self.wait_to_be_clickable("root")
         if (
             self.root.get_attribute("readonly")
             or self.root.get_attribute("readOnly")

--- a/pytest_splunk_addon_ui_smartx/components/controls/textarea.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/textarea.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/textbox.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/textbox.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/controls/textbox.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/textbox.py
@@ -44,6 +44,7 @@ class TextBox(BaseControl):
         set value of the textbox
         """
         # first condition added for safari browser
+        self.wait_to_be_clickable("input")
         if self.browser.capabilities["browserName"] == "Safari":
             self.input.send_keys(Keys.COMMAND)
             self.input.send_keys("a")

--- a/pytest_splunk_addon_ui_smartx/components/controls/toggle.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/toggle.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -91,6 +91,7 @@ class Dropdown(BaseComponent):
         )
 
         for each in self.get_elements("values"):
+            self.wait_to_be_clickable(each)
             if each.text.strip().lower() == value.lower():
                 each.click()
                 return True
@@ -155,6 +156,7 @@ class Dropdown(BaseComponent):
         Returns a generator list for the options available in the add input dropdown
             :return: Returns Generator list of values
         """
+        self.wait_to_be_clickable("root")
         self.root.click()
         popover_id = "#" + self.root.get_attribute("data-test-popover-id")
         self.elements.update(

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -91,7 +91,6 @@ class Dropdown(BaseComponent):
         )
 
         for each in self.get_elements("values"):
-            self.wait_to_be_clickable(each)
             if each.text.strip().lower() == value.lower():
                 each.click()
                 return True

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -97,7 +97,7 @@ class Dropdown(BaseComponent):
         else:
             raise ValueError("{} not found in select list".format(value))
 
-    def select_nested(self, values):
+    def select_sub_input(self, values: list):
         """
         Selects the values we want from the type list in defined order
             :param values: Dropdown values list in order we want to select
@@ -106,6 +106,7 @@ class Dropdown(BaseComponent):
         if not isinstance(values, list):
             raise ValueError("{} has to be of type list".format(values))
 
+        self.wait_to_be_clickable("root")
         self.root.click()
         popoverid = "#" + self.root.get_attribute("data-test-popover-id")
         dropdown_selector = ' [data-test="item"] [data-test="label"]'
@@ -164,6 +165,35 @@ class Dropdown(BaseComponent):
             }
         )
         return [each.text.strip() for each in self.get_elements("type_list")]
+    
+    def get_sub_input_list(self, values):
+        """
+        Returns a generator list for the options available in the add input dropdown
+            :return: Returns Generator list of values
+        """
+        if not isinstance(values, list):
+            raise ValueError("{} has to be of type list".format(values))
+        
+        self.wait_to_be_clickable("root")
+        self.root.click()
+        popoverid = "#" + self.root.get_attribute("data-test-popover-id")
+        dropdown_selector = ' [data-test="item"] [data-test="label"]'
+        for value in values:
+            found = False
+            self.elements.update(
+                {"dropdown_options": Selector(select=popoverid + dropdown_selector)}
+            )
+            for each in self.get_elements("dropdown_options"):
+                if each.text.strip().lower() == value.lower():
+                    found = True
+                    each.click()
+                    time.sleep(
+                        1
+                    )  # sleep here prevents broken animation resulting in unclicable button
+                    break
+            if not found:
+                raise ValueError("{} not found in select list".format(value))
+        return [each.text.strip() for each in self.get_elements("dropdown_options")]
 
     def get_pagination_list(self):
         """

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -48,6 +48,7 @@ class Dropdown(BaseComponent):
             :param value: The value in which we want to select
             :return: Returns True if successful, otherwise raises an error
         """
+        self.wait_to_be_clickable("root")
         self.root.click()
         popover_id = "#" + self.root.get_attribute("data-test-popover-id")
         self.elements.update(
@@ -75,7 +76,7 @@ class Dropdown(BaseComponent):
             :param value: The value in which we want to select
             :return: Returns True if successful, otherwise raises an error
         """
-
+        self.wait_to_be_clickable("root")
         self.root.click()
         popover_id = "#" + self.root.get_attribute("data-test-popover-id")
         self.elements.update(
@@ -135,6 +136,7 @@ class Dropdown(BaseComponent):
             :return: Returns True if successful, otherwise raises an error
         """
         if open_dropdown:
+            self.wait_to_be_clickable("root")
             self.root.click()
         popover_id = "#" + self.root.get_attribute("data-test-popover-id")
         self.elements.update(
@@ -165,12 +167,13 @@ class Dropdown(BaseComponent):
             }
         )
         return [each.text.strip() for each in self.get_elements("type_list")]
-    
+
     def get_pagination_list(self):
         """
         Returns a generator list for the pagination text available in the add input dropdown
             :return: Returns Generator list of values
         """
+        self.wait_to_be_clickable("root")
         self.root.click()
         popover_id = "#" + self.root.get_attribute("data-test-popover-id")
         self.elements.update(
@@ -185,6 +188,7 @@ class Dropdown(BaseComponent):
         Returns a generator list for the input types available in the add input dropdown
             :return: Returns Generator list of values
         """
+        self.wait_to_be_clickable("root")
         self.root.click()
         popover_id = "#" + self.root.get_attribute("data-test-popover-id")
         self.elements.update(

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -97,7 +97,7 @@ class Dropdown(BaseComponent):
         else:
             raise ValueError("{} not found in select list".format(value))
 
-    def select_sub_input(self, values: list):
+    def select_nested(self, values: list):
         """
         Selects the values we want from the type list in defined order
             :param values: Dropdown values list in order we want to select
@@ -166,35 +166,6 @@ class Dropdown(BaseComponent):
         )
         return [each.text.strip() for each in self.get_elements("type_list")]
     
-    def get_sub_input_list(self, values):
-        """
-        Returns a generator list for the options available in the add input dropdown
-            :return: Returns Generator list of values
-        """
-        if not isinstance(values, list):
-            raise ValueError("{} has to be of type list".format(values))
-        
-        self.wait_to_be_clickable("root")
-        self.root.click()
-        popoverid = "#" + self.root.get_attribute("data-test-popover-id")
-        dropdown_selector = ' [data-test="item"] [data-test="label"]'
-        for value in values:
-            found = False
-            self.elements.update(
-                {"dropdown_options": Selector(select=popoverid + dropdown_selector)}
-            )
-            for each in self.get_elements("dropdown_options"):
-                if each.text.strip().lower() == value.lower():
-                    found = True
-                    each.click()
-                    time.sleep(
-                        1
-                    )  # sleep here prevents broken animation resulting in unclicable button
-                    break
-            if not found:
-                raise ValueError("{} not found in select list".format(value))
-        return [each.text.strip() for each in self.get_elements("dropdown_options")]
-
     def get_pagination_list(self):
         """
         Returns a generator list for the pagination text available in the add input dropdown

--- a/pytest_splunk_addon_ui_smartx/components/entity.py
+++ b/pytest_splunk_addon_ui_smartx/components/entity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/input_table.py
+++ b/pytest_splunk_addon_ui_smartx/components/input_table.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/login.py
+++ b/pytest_splunk_addon_ui_smartx/components/login.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/message_tray.py
+++ b/pytest_splunk_addon_ui_smartx/components/message_tray.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/table.py
+++ b/pytest_splunk_addon_ui_smartx/components/table.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/components/table.py
+++ b/pytest_splunk_addon_ui_smartx/components/table.py
@@ -346,10 +346,12 @@ class Table(BaseComponent):
         # Click on action
         with self.wait_stale():
             _row = self._get_row(name)
+            time.sleep(0.5)
             _row.find_element(*list(self.elements["delete"]._asdict().values())).click()
 
             self.wait_for("delete_prompt")
             if cancel:
+                self.wait_to_be_clickable("delete_cancel")
                 self.delete_cancel.click()
                 self.wait_until("delete_cancel")
                 return True

--- a/pytest_splunk_addon_ui_smartx/components/tabs.py
+++ b/pytest_splunk_addon_ui_smartx/components/tabs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/pages/__init__.py
+++ b/pytest_splunk_addon_ui_smartx/pages/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/pages/logging.py
+++ b/pytest_splunk_addon_ui_smartx/pages/logging.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/pages/login.py
+++ b/pytest_splunk_addon_ui_smartx/pages/login.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/pages/page.py
+++ b/pytest_splunk_addon_ui_smartx/pages/page.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/pages/proxy.py
+++ b/pytest_splunk_addon_ui_smartx/pages/proxy.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -141,7 +141,7 @@ def ucc_smartx_configs(request):
     else:
         headless_run = False
         
-    if request.config.getoption("--saucuelabs"):
+    if request.config.getoption("--saucelabs"):
         saucelabs_run = True
         LOGGER.debug("--saucelabs")
     

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -94,11 +94,14 @@ def pytest_addoption(parser):
     group.addoption(
         "--headless", action="store_true", help="Run the test case on headless mode"
     )
-
+    
+    group.addoption(
+        "--selenium-dns", action="store_true", help="selenium dns in k8s"
+    )
 
 SmartConfigs = namedtuple(
     "SmartConfigs",
-    ["driver", "driver_version", "local_run", "retry_count", "headless_run"],
+    ["driver", "driver_version", "local_run", "retry_count", "headless_run", "selenium_dns"],
 )
 
 
@@ -136,6 +139,8 @@ def ucc_smartx_configs(request):
         LOGGER.debug("--headless")
     else:
         headless_run = False
+    
+    selenium_dns = request.config.getoption("--selenium-dns")
 
     LOGGER.info(
         "Calling SeleniumHelper with:: browser={driver}, debug={local_run}, headless={headless_run})".format(
@@ -148,6 +153,7 @@ def ucc_smartx_configs(request):
         local_run=local_run,
         retry_count=retry_count,
         headless_run=headless_run,
+        selenium_dns=selenium_dns
     )
     return smartx_configs
 
@@ -182,6 +188,7 @@ def ucc_smartx_selenium_helper(
                 cred=(splunk["username"], splunk["password"]),
                 headless=ucc_smartx_configs.headless_run,
                 test_case=test_case,
+                selenium_dns=ucc_smartx_configs.selenium_dns,
             )
             break
         except Exception as e:

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -96,13 +96,13 @@ def pytest_addoption(parser):
     )
     
     group.addoption(
-        "--selenium-dns", action="store_true", help="selenium dns in k8s"
+        "--selenium-dns", action="store", help="selenium dns in k8s"
     )
 
 
 SmartConfigs = namedtuple(
     "SmartConfigs",
-    ["driver", "driver_version", "local_run", "retry_count", "headless_run"],
+    ["driver", "driver_version", "local_run", "retry_count", "headless_run", "selenium_dns"],
 )
 
 
@@ -159,7 +159,7 @@ def ucc_smartx_configs(request):
         local_run=local_run,
         retry_count=retry_count,
         headless_run=headless_run,
-        #selenium_dns=selenium_dns
+        selenium_dns=selenium_dns
     )
     return smartx_configs
 
@@ -194,7 +194,7 @@ def ucc_smartx_selenium_helper(
                 cred=(splunk["username"], splunk["password"]),
                 headless=ucc_smartx_configs.headless_run,
                 test_case=test_case,
-                #selenium_dns=ucc_smartx_configs.selenium_dns,
+                selenium_dns=ucc_smartx_configs.selenium_dns,
             )
             break
         except Exception as e:

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -102,7 +102,7 @@ def pytest_addoption(parser):
 
 SmartConfigs = namedtuple(
     "SmartConfigs",
-    ["driver", "driver_version", "local_run", "retry_count", "headless_run", "saucelabs"],
+    ["driver", "driver_version", "local_run", "retry_count", "headless_run", "saucelabs_run"],
 )
 
 

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -144,6 +144,8 @@ def ucc_smartx_configs(request):
     if request.config.getoption("--saucelabs"):
         saucelabs_run = True
         LOGGER.debug("--saucelabs")
+    else:
+        saucelabs_run = False
     
     LOGGER.info(
         "Calling SeleniumHelper with:: browser={driver}, debug={local_run}, headless={headless_run}), saucelabs={saucelabs_run}".format(

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -156,7 +156,7 @@ def get_browser_scope(fixture_name, config):
     """
     Set the scope of the browser dynamically.
     """
-    if config.getoption("--local") and config.getoption("--persist-browser"):
+    if config.getoption("--persist-browser"):
         return "session"
     else:
         return "function"

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -94,7 +94,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--headless", action="store_true", help="Run the test case on headless mode"
     )
-    
+
     group.addoption(
         "--saucelabs", action="store_true", help="Run the tests using saucelabs"
     )
@@ -102,7 +102,14 @@ def pytest_addoption(parser):
 
 SmartConfigs = namedtuple(
     "SmartConfigs",
-    ["driver", "driver_version", "local_run", "retry_count", "headless_run", "saucelabs_run"],
+    [
+        "driver",
+        "driver_version",
+        "local_run",
+        "retry_count",
+        "headless_run",
+        "saucelabs_run",
+    ],
 )
 
 
@@ -140,16 +147,19 @@ def ucc_smartx_configs(request):
         LOGGER.debug("--headless")
     else:
         headless_run = False
-        
+
     if request.config.getoption("--saucelabs"):
         saucelabs_run = True
         LOGGER.debug("--saucelabs")
     else:
         saucelabs_run = False
-    
+
     LOGGER.info(
         "Calling SeleniumHelper with:: browser={driver}, debug={local_run}, headless={headless_run}), saucelabs={saucelabs_run}".format(
-            driver=driver, local_run=local_run, headless_run=headless_run, saucelabs_run=saucelabs_run
+            driver=driver,
+            local_run=local_run,
+            headless_run=headless_run,
+            saucelabs_run=saucelabs_run,
         )
     )
     smartx_configs = SmartConfigs(

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -94,11 +94,15 @@ def pytest_addoption(parser):
     group.addoption(
         "--headless", action="store_true", help="Run the test case on headless mode"
     )
+    
+    group.addoption(
+        "--saucelabs", action="store_true", help="Run the tests using saucelabs"
+    )
 
 
 SmartConfigs = namedtuple(
     "SmartConfigs",
-    ["driver", "driver_version", "local_run", "retry_count", "headless_run"],
+    ["driver", "driver_version", "local_run", "retry_count", "headless_run", "saucelabs"],
 )
 
 
@@ -136,10 +140,14 @@ def ucc_smartx_configs(request):
         LOGGER.debug("--headless")
     else:
         headless_run = False
+        
+    if request.config.getoption("--saucuelabs"):
+        saucelabs_run = True
+        LOGGER.debug("--saucelabs")
     
     LOGGER.info(
-        "Calling SeleniumHelper with:: browser={driver}, debug={local_run}, headless={headless_run})".format(
-            driver=driver, local_run=local_run, headless_run=headless_run
+        "Calling SeleniumHelper with:: browser={driver}, debug={local_run}, headless={headless_run}), saucelabs={saucelabs_run}".format(
+            driver=driver, local_run=local_run, headless_run=headless_run, saucelabs_run=saucelabs_run
         )
     )
     smartx_configs = SmartConfigs(
@@ -148,6 +156,7 @@ def ucc_smartx_configs(request):
         local_run=local_run,
         retry_count=retry_count,
         headless_run=headless_run,
+        saucelabs_run=saucelabs_run,
     )
     return smartx_configs
 
@@ -181,6 +190,7 @@ def ucc_smartx_selenium_helper(
                 debug=ucc_smartx_configs.local_run,
                 cred=(splunk["username"], splunk["password"]),
                 headless=ucc_smartx_configs.headless_run,
+                saucelabs=ucc_smartx_configs.saucelabs_run,
                 test_case=test_case,
             )
             break

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -94,7 +94,6 @@ def pytest_addoption(parser):
     group.addoption(
         "--headless", action="store_true", help="Run the test case on headless mode"
     )
-    
 
 
 SmartConfigs = namedtuple(
@@ -138,7 +137,6 @@ def ucc_smartx_configs(request):
     else:
         headless_run = False
     
-
     LOGGER.info(
         "Calling SeleniumHelper with:: browser={driver}, debug={local_run}, headless={headless_run})".format(
             driver=driver, local_run=local_run, headless_run=headless_run

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -95,14 +95,11 @@ def pytest_addoption(parser):
         "--headless", action="store_true", help="Run the test case on headless mode"
     )
     
-    group.addoption(
-        "--selenium-dns", action="store", help="selenium dns in k8s"
-    )
 
 
 SmartConfigs = namedtuple(
     "SmartConfigs",
-    ["driver", "driver_version", "local_run", "retry_count", "headless_run", "selenium_dns"],
+    ["driver", "driver_version", "local_run", "retry_count", "headless_run"],
 )
 
 
@@ -140,12 +137,6 @@ def ucc_smartx_configs(request):
         LOGGER.debug("--headless")
     else:
         headless_run = False
-
-    if request.config.getoption("--selenium-dns"):
-        selenium_dns = request.config.getoption("--selenium-dns")
-        LOGGER.debug(f"--selenium-dns: {selenium_dns}")
-    else:
-        headless_run = False
     
 
     LOGGER.info(
@@ -159,7 +150,6 @@ def ucc_smartx_configs(request):
         local_run=local_run,
         retry_count=retry_count,
         headless_run=headless_run,
-        selenium_dns=selenium_dns
     )
     return smartx_configs
 
@@ -194,7 +184,6 @@ def ucc_smartx_selenium_helper(
                 cred=(splunk["username"], splunk["password"]),
                 headless=ucc_smartx_configs.headless_run,
                 test_case=test_case,
-                selenium_dns=ucc_smartx_configs.selenium_dns,
             )
             break
         except Exception as e:

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -101,7 +101,7 @@ def pytest_addoption(parser):
 
 SmartConfigs = namedtuple(
     "SmartConfigs",
-    ["driver", "driver_version", "local_run", "retry_count", "headless_run", "selenium_dns"],
+    ["driver", "driver_version", "local_run", "retry_count", "headless_run"],
 )
 
 
@@ -153,7 +153,7 @@ def ucc_smartx_configs(request):
         local_run=local_run,
         retry_count=retry_count,
         headless_run=headless_run,
-        selenium_dns=selenium_dns
+        #selenium_dns=selenium_dns
     )
     return smartx_configs
 

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -95,10 +95,6 @@ def pytest_addoption(parser):
         "--headless", action="store_true", help="Run the test case on headless mode"
     )
 
-    group.addoption(
-        "--saucelabs", action="store_true", help="Run the tests using saucelabs"
-    )
-
 
 SmartConfigs = namedtuple(
     "SmartConfigs",
@@ -108,7 +104,6 @@ SmartConfigs = namedtuple(
         "local_run",
         "retry_count",
         "headless_run",
-        "saucelabs_run",
     ],
 )
 
@@ -148,18 +143,11 @@ def ucc_smartx_configs(request):
     else:
         headless_run = False
 
-    if request.config.getoption("--saucelabs"):
-        saucelabs_run = True
-        LOGGER.debug("--saucelabs")
-    else:
-        saucelabs_run = False
-
     LOGGER.info(
-        "Calling SeleniumHelper with:: browser={driver}, debug={local_run}, headless={headless_run}), saucelabs={saucelabs_run}".format(
+        "Calling SeleniumHelper with:: browser={driver}, debug={local_run}, headless={headless_run})".format(
             driver=driver,
             local_run=local_run,
             headless_run=headless_run,
-            saucelabs_run=saucelabs_run,
         )
     )
     smartx_configs = SmartConfigs(
@@ -168,7 +156,6 @@ def ucc_smartx_configs(request):
         local_run=local_run,
         retry_count=retry_count,
         headless_run=headless_run,
-        saucelabs_run=saucelabs_run,
     )
     return smartx_configs
 
@@ -177,7 +164,7 @@ def get_browser_scope(fixture_name, config):
     """
     Set the scope of the browser dynamically.
     """
-    if config.getoption("--persist-browser"):
+    if config.getoption("--local") and config.getoption("--persist-browser"):
         return "session"
     else:
         return "function"
@@ -202,7 +189,6 @@ def ucc_smartx_selenium_helper(
                 debug=ucc_smartx_configs.local_run,
                 cred=(splunk["username"], splunk["password"]),
                 headless=ucc_smartx_configs.headless_run,
-                saucelabs=ucc_smartx_configs.saucelabs_run,
                 test_case=test_case,
             )
             break

--- a/pytest_splunk_addon_ui_smartx/plugin.py
+++ b/pytest_splunk_addon_ui_smartx/plugin.py
@@ -99,6 +99,7 @@ def pytest_addoption(parser):
         "--selenium-dns", action="store_true", help="selenium dns in k8s"
     )
 
+
 SmartConfigs = namedtuple(
     "SmartConfigs",
     ["driver", "driver_version", "local_run", "retry_count", "headless_run"],
@@ -139,8 +140,13 @@ def ucc_smartx_configs(request):
         LOGGER.debug("--headless")
     else:
         headless_run = False
+
+    if request.config.getoption("--selenium-dns"):
+        selenium_dns = request.config.getoption("--selenium-dns")
+        LOGGER.debug(f"--selenium-dns: {selenium_dns}")
+    else:
+        headless_run = False
     
-    selenium_dns = request.config.getoption("--selenium-dns")
 
     LOGGER.info(
         "Calling SeleniumHelper with:: browser={driver}, debug={local_run}, headless={headless_run})".format(
@@ -188,7 +194,7 @@ def ucc_smartx_selenium_helper(
                 cred=(splunk["username"], splunk["password"]),
                 headless=ucc_smartx_configs.headless_run,
                 test_case=test_case,
-                selenium_dns=ucc_smartx_configs.selenium_dns,
+                #selenium_dns=ucc_smartx_configs.selenium_dns,
             )
             break
         except Exception as e:

--- a/pytest_splunk_addon_ui_smartx/utils.py
+++ b/pytest_splunk_addon_ui_smartx/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run_splunk.sh
+++ b/run_splunk.sh
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/ui/test_splunk_ta_example_addon_input_common.py
+++ b/tests/ui/test_splunk_ta_example_addon_input_common.py
@@ -380,7 +380,7 @@ class TestInput(UccTester):
         """Verifies Back button after dropdown multilevel select"""
         input_page = InputPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
         value_to_test = ["Example Input One", "Example Input Two", "Group One"]
-        input_page.create_new_input.select_sub_input(["Group One", "Back"])
+        input_page.create_new_input.select_nested(["Group One", "Back"])
         self.assert_util(input_page.create_new_input.get_inputs_list, value_to_test)
 
     @pytest.mark.execute_enterprise_cloud_true
@@ -395,7 +395,7 @@ class TestInput(UccTester):
             "Example Input Three",
             "Example Input Four",
         ]
-        input_page.create_new_input.select_sub_input(["Group One", "Example Input Three"])
+        input_page.create_new_input.select_nested(["Group One", "Example Input Three"])
         input_page.entity3.name.set_value("dummy_input_three")
         input_page.entity3.interval.set_value("50")
         input_page.entity3.save()

--- a/tests/ui/test_splunk_ta_example_addon_input_common.py
+++ b/tests/ui/test_splunk_ta_example_addon_input_common.py
@@ -380,7 +380,7 @@ class TestInput(UccTester):
         """Verifies Back button after dropdown multilevel select"""
         input_page = InputPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
         value_to_test = ["Example Input One", "Example Input Two", "Group One"]
-        input_page.create_new_input.select_nested(["Group One", "Back"])
+        input_page.create_new_input.select_sub_input(["Group One", "Back"])
         self.assert_util(input_page.create_new_input.get_inputs_list, value_to_test)
 
     @pytest.mark.execute_enterprise_cloud_true
@@ -395,7 +395,7 @@ class TestInput(UccTester):
             "Example Input Three",
             "Example Input Four",
         ]
-        input_page.create_new_input.select_nested(["Group One", "Example Input Three"])
+        input_page.create_new_input.select_sub_input(["Group One", "Example Input Three"])
         input_page.entity3.name.set_value("dummy_input_three")
         input_page.entity3.interval.set_value("50")
         input_page.entity3.save()

--- a/tests/unit/test_base_test.py
+++ b/tests/unit/test_base_test.py
@@ -85,7 +85,9 @@ default_args_for_selenium_helper = {
 
 
 def test_selenium_helper_raise_exception_with_given_invalid_browser_version():
-    with pytest.raises(Exception, match="No valid browser found.") as e:
+    with pytest.raises(Exception, match="No valid browser found.") as e, patch(
+        "os.environ.get", lambda x: x if x != "SELENIUM_HOST" else None
+    ):
         SeleniumHelper(**{**default_args_for_selenium_helper, "browser": "aa"})
 
 
@@ -227,7 +229,7 @@ def test_constructor_selenium_helper(browser, webdriver, debug):
 def test_desired_capabilities_for_saucelabs(browser, expected_config):
     importlib.reload(pytest_splunk_addon_ui_smartx.base_test)
     with patch("selenium.webdriver.Remote") as webdriver, patch(
-        "os.environ.get", lambda x: x
+        "os.environ.get", lambda x: x if x != "SELENIUM_HOST" else None
     ):
         pytest_splunk_addon_ui_smartx.base_test.SeleniumHelper(
             **{
@@ -565,7 +567,7 @@ def test_update_sauce_job(status):
 
     importlib.reload(pytest_splunk_addon_ui_smartx.base_test)
     with patch("selenium.webdriver.Remote"), patch("requests.put") as req, patch(
-        "os.environ.get", lambda x: x
+        "os.environ.get", lambda x: x if x != "SELENIUM_HOST" else None
     ):
         selenium_helper = pytest_splunk_addon_ui_smartx.base_test.SeleniumHelper(
             **{**default_args_for_selenium_helper, "debug": False}


### PR DESCRIPTION
This PR introduces execution of UI tests on selenium standalone instance. This is achieved by usage of `SELENIUM_HOST` env var.
Changes:

- introduction of selenium standalone UI tests execution
- fixes for failing test cases, in most cases `self.wait_to_be_clickable("element")`
- improved `toggle()` of checkbox component
- fixes for unit tests

BREAKING CHANGE: Default UI tests executor changed from Saucelabs to Selenium standalone