### PR TITLE
fix: fixes for flaky table, multiselect, dropdown

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/controls/multi_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/multi_select.py
@@ -100,7 +100,13 @@ class MultiSelect(BaseControl):
         )
         for each in self.get_elements("values"):
             if each.text.strip().lower() == value.lower():
-                each.click()
+                try:
+                    each.click()
+                except ElementClickInterceptedException:
+                    self.elements.update({value.lower(): Selector(
+                        select=popover_id + f' [data-test="option"][data-test-value="{value.lower()}"]')})
+                    self.hover_over_element(f"{value.lower()}")
+                    each.click()
                 self.wait_for("input")
                 return True
         else:

--- a/pytest_splunk_addon_ui_smartx/components/controls/multi_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/multi_select.py
@@ -103,8 +103,14 @@ class MultiSelect(BaseControl):
                 try:
                     each.click()
                 except ElementClickInterceptedException:
-                    self.elements.update({value.lower(): Selector(
-                        select=popover_id + f' [data-test="option"][data-test-value="{value.lower()}"]')})
+                    self.elements.update(
+                        {
+                            value.lower(): Selector(
+                                select=popover_id
+                                + f' [data-test="option"][data-test-value="{value.lower()}"]'
+                            )
+                        }
+                    )
                     self.hover_over_element(f"{value.lower()}")
                     each.click()
                 self.wait_for("input")

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -122,14 +122,16 @@ class Dropdown(BaseComponent):
                     try:
                         each.click()
                     except ElementClickInterceptedException:
-                        self.hover_over_element("root") #avoid tooltip interception
+                        self.hover_over_element("root")  # avoid tooltip interception
                         each.click()
                     time.sleep(
                         1
                     )  # sleep here prevents broken animation resulting in unclicable button
                     break
             if not found:
-                raise ValueError(f"{value} not found in select list. Values found {[_ for _.text.strip().lower in self.get_elements('values')]}")
+                raise ValueError(
+                    f"{value} not found in select list. Values found {[_ for _.text.strip().lower in self.get_elements('values')]}"
+                )
         return True
 
     def select_input_type(self, value, open_dropdown=True):

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -16,6 +16,7 @@
 
 import time
 from .base_component import BaseComponent, Selector
+from selenium.common.exceptions import ElementClickInterceptedException
 
 
 class Dropdown(BaseComponent):
@@ -106,7 +107,6 @@ class Dropdown(BaseComponent):
         """
         if not isinstance(values, list):
             raise ValueError("{} has to be of type list".format(values))
-
         self.wait_to_be_clickable("root")
         self.root.click()
         popoverid = "#" + self.root.get_attribute("data-test-popover-id")
@@ -119,13 +119,17 @@ class Dropdown(BaseComponent):
             for each in self.get_elements("dropdown_options"):
                 if each.text.strip().lower() == value.lower():
                     found = True
-                    each.click()
+                    try:
+                        each.click()
+                    except ElementClickInterceptedException:
+                        self.hover_over_element("root") #avoid tooltip interception
+                        each.click()
                     time.sleep(
                         1
                     )  # sleep here prevents broken animation resulting in unclicable button
                     break
             if not found:
-                raise ValueError("{} not found in select list".format(value))
+                raise ValueError(f"{value} not found in select list. Values found {[_ for _.text.strip().lower in self.get_elements('values')]}")
         return True
 
     def select_input_type(self, value, open_dropdown=True):

--- a/pytest_splunk_addon_ui_smartx/components/table.py
+++ b/pytest_splunk_addon_ui_smartx/components/table.py
@@ -363,6 +363,7 @@ class Table(BaseComponent):
                 self.wait_for_text("delete_prompt")
                 return self.get_clear_text(self.delete_prompt)
             else:
+                self.wait_to_be_clickable("delete_btn")
                 self.delete_btn.click()
                 self.wait_until("waitspinner")
 


### PR DESCRIPTION
This PR provides exception handling for multiselect and dropdown to get rid of flaky test cases.
Additionaly wait_to_be_clickable added in table module.