### PR TITLE
fix: ADDON-68980 single_select is_editable fix for combobox

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -47,7 +47,9 @@ class SingleSelect(BaseControl):
             )
 
         self.element_selector = container.select + (
-            ' [data-test="combo-box"]' if self.allow_new_values else ' [data-test="select"]'
+            ' [data-test="combo-box"]'
+            if self.allow_new_values
+            else ' [data-test="select"]'
         )
 
         self.elements.update(
@@ -369,13 +371,13 @@ class SingleSelect(BaseControl):
         """
         if self.allow_new_values:
             return (
-                    not self.selected.get_attribute("readonly")
-                    and not self.selected.get_attribute("readOnly")
-                    and not self.selected.get_attribute("disabled")
+                not self.selected.get_attribute("readonly")
+                and not self.selected.get_attribute("readOnly")
+                and not self.selected.get_attribute("disabled")
             )
         else:
             return (
-                    not self.root.get_attribute("readonly")
-                    and not self.root.get_attribute("readOnly")
-                    and not self.root.get_attribute("disabled")
+                not self.root.get_attribute("readonly")
+                and not self.root.get_attribute("readOnly")
+                and not self.root.get_attribute("disabled")
             )

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -47,7 +47,7 @@ class SingleSelect(BaseControl):
             )
 
         self.element_selector = container.select + (
-            ' [data-test="combo-box"]' if allow_new_values else ' [data-test="select"]'
+            ' [data-test="combo-box"]' if self.allow_new_values else ' [data-test="select"]'
         )
 
         self.elements.update(
@@ -367,11 +367,15 @@ class SingleSelect(BaseControl):
         """
         Returns True if the SingleSelect is editable, False otherwise
         """
-        if (
-            self.root.get_attribute("readonly")
-            or self.root.get_attribute("readOnly")
-            or self.root.get_attribute("disabled")
-        ):
-            return False
+        if self.allow_new_values:
+            return (
+                    not self.selected.get_attribute("readonly")
+                    and not self.selected.get_attribute("readOnly")
+                    and not self.selected.get_attribute("disabled")
+            )
         else:
-            return True
+            return (
+                    not self.root.get_attribute("readonly")
+                    and not self.root.get_attribute("readOnly")
+                    and not self.root.get_attribute("disabled")
+            )

--- a/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
+++ b/pytest_splunk_addon_ui_smartx/components/controls/single_select.py
@@ -47,9 +47,7 @@ class SingleSelect(BaseControl):
             )
 
         self.element_selector = container.select + (
-            ' [data-test="combo-box"]'
-            if self.allow_new_values
-            else ' [data-test="select"]'
+            ' [data-test="combo-box"]' if allow_new_values else ' [data-test="select"]'
         )
 
         self.elements.update(

--- a/pytest_splunk_addon_ui_smartx/components/dropdown.py
+++ b/pytest_splunk_addon_ui_smartx/components/dropdown.py
@@ -130,7 +130,7 @@ class Dropdown(BaseComponent):
                     break
             if not found:
                 raise ValueError(
-                    f"{value} not found in select list. Values found {[_ for _.text.strip().lower in self.get_elements('values')]}"
+                    f"{value} not found in select list. Values found {[_.text.strip().lower() for _ in self.get_elements('dropdown_options')]}"
                 )
         return True
 

--- a/tests/testdata/Splunk_TA_UCCExample/globalConfig.json
+++ b/tests/testdata/Splunk_TA_UCCExample/globalConfig.json
@@ -539,6 +539,7 @@
                             "type": "singleSelect",
                             "options": {
                                 "createSearchChoice": true,
+                                "disableonEdit": true,
                                 "autoCompleteFields": [
                                     {
                                         "label": "Group1",

--- a/tests/ui/test_splunk_ta_example_addon_input_1.py
+++ b/tests/ui/test_splunk_ta_example_addon_input_1.py
@@ -883,7 +883,6 @@ class TestInput(UccTester):
         input_page.table.edit_row("dummy_input_one")
         input_page.entity1.example_checkbox.uncheck()
         input_page.entity1.example_radio.select("No")
-        input_page.entity1.single_select_group_test.select("four")
         input_page.entity1.multiple_select_test.deselect("b")
         input_page.entity1.interval.set_value("3600")
         input_page.entity1.index.select("main")
@@ -919,7 +918,6 @@ class TestInput(UccTester):
         input_page.table.edit_row("dummy_input_one")
         input_page.entity1.example_checkbox.uncheck()
         input_page.entity1.example_radio.select("No")
-        input_page.entity1.single_select_group_test.select("Four")
         input_page.entity1.multiple_select_test.deselect("b")
         input_page.entity1.interval.set_value("3600")
         input_page.entity1.index.select("main")
@@ -942,7 +940,7 @@ class TestInput(UccTester):
             "object": "edit_object",
             "object_fields": "edit_field",
             "order_by": "LastDate",
-            "singleSelectTest": "four",
+            "singleSelectTest": "two",
             "start_date": "2020-20-20T20:20:20.000z",
             "disabled": 0,
             "example_textarea_field": "line3\nline4",

--- a/tests/ui/test_splunk_ta_example_addon_input_1.py
+++ b/tests/ui/test_splunk_ta_example_addon_input_1.py
@@ -869,6 +869,7 @@ class TestInput(UccTester):
         input_page = InputPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
         input_page.table.edit_row("dummy_input_one")
         self.assert_util(input_page.entity1.name.is_editable, False)
+        self.assert_util(input_page.entity1.single_select_group_test.is_editable, False)
 
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.forwarder


### PR DESCRIPTION
Fix for reported issue with is_editable() of SingleSelect: https://splunk.atlassian.net/browse/ADDON-68980

Issue was present when SingleSelect element was configured to allow new values - updated tests scenarios.