### PR TITLE
ci: align semantic regex for version update

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -43,7 +43,7 @@
             },
             {
               "files": ["pyproject.toml"],
-              "from": "version = \"[0-9]+.[0-9]+.[0-9]+\"",
+              "from": "version = \"[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9]+(\\.[0-9]+)*)?\"$",
               "to": "version = \"${nextRelease.version}\"",
               "results": [
                 {


### PR DESCRIPTION
Current regex is not matching beta releases - this PR fixes that.
Test run: https://github.com/splunk/test-addonfactory-repo/actions/runs/9516876272