### PR TITLE
fix: define browser resolution for all chrome tests

### DIFF
--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -154,9 +154,9 @@ class SeleniumHelper:
         chrome_opts.add_argument("--ignore-ssl-errors=yes")
         chrome_opts.add_argument("--ignore-certificate-errors")
         chrome_opts.add_argument("--disable-dev-shm-usage")
+        chrome_opts.add_argument("--window-size=1280,768")
         if headless_run:
             chrome_opts.add_argument("--headless")
-            chrome_opts.add_argument("--window-size=1280,768")
         return chrome_opts
 
     @staticmethod


### PR DESCRIPTION
Specifying window resolution for UI tests resolves `ElementNotInteractableException` error when element to be found with xpath is not visible and browser page has to be scrolled down.