### PR TITLE
fix: dynamic handle input status toggle [ADDON-71796]

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/input_table.py
+++ b/pytest_splunk_addon_ui_smartx/components/input_table.py
@@ -65,21 +65,21 @@ class InputTable(Table):
         status_button = _row.find_element(
             *list(self.elements["status_toggle"]._asdict().values())
         )
-        input_enabled = status_button.get_attribute("data-selected")
+        input_enabled = (
+            True
+            if status_button.get_attribute("data-selected").lower().strip() == "true"
+            else False
+        )
         if enable:
             if input_enabled:
-                raise Exception(
-                    "The input is already enabled"
-                )
+                raise Exception("The input is already enabled")
             elif not input_enabled:
                 status_button.click()
                 self.wait_until("switch_button_status")
                 return True
         else:
             if not input_enabled:
-                raise Exception(
-                    "The input is already disabled"
-                )
+                raise Exception("The input is already disabled")
             elif input_enabled:
                 status_button.click()
                 self.wait_until("switch_button_status")

--- a/pytest_splunk_addon_ui_smartx/components/input_table.py
+++ b/pytest_splunk_addon_ui_smartx/components/input_table.py
@@ -73,14 +73,14 @@ class InputTable(Table):
         if enable:
             if input_enabled:
                 raise Exception("The input is already enabled")
-            elif not input_enabled:
+            else:
                 status_button.click()
                 self.wait_until("switch_button_status")
                 return True
         else:
             if not input_enabled:
                 raise Exception("The input is already disabled")
-            elif input_enabled:
+            else:
                 status_button.click()
                 self.wait_until("switch_button_status")
                 return True

--- a/pytest_splunk_addon_ui_smartx/components/input_table.py
+++ b/pytest_splunk_addon_ui_smartx/components/input_table.py
@@ -62,32 +62,25 @@ class InputTable(Table):
             :return: Bool whether or not enabling or disabling the field was successful, If the field was already in the state we wanted it in, then it will return an exception
         """
         _row = self._get_row(name)
-        input_status = _row.find_element(
-            *list(self.elements["input_status"]._asdict().values())
-        )
-        status = (
-            input_status.find_element_by_css_selector('[data-test="status"]')
-            .text.strip()
-            .lower()
-        )
         status_button = _row.find_element(
             *list(self.elements["status_toggle"]._asdict().values())
         )
+        input_enabled = status_button.get_attribute("data-selected")
         if enable:
-            if status == "enabled":
+            if input_enabled:
                 raise Exception(
-                    "The input is already {}".format(self.input_status.text.strip())
+                    "The input is already enabled"
                 )
-            elif status == "disabled":
+            elif not input_enabled:
                 status_button.click()
                 self.wait_until("switch_button_status")
                 return True
         else:
-            if status == "disabled":
+            if not input_enabled:
                 raise Exception(
-                    "The input is already {}".format(self.input_status.text.strip())
+                    "The input is already disabled"
                 )
-            elif status == "enabled":
+            elif input_enabled:
                 status_button.click()
                 self.wait_until("switch_button_status")
                 return True


### PR DESCRIPTION
As requested in https://splunk.atlassian.net/browse/ADDON-71796.

input_status_toggle() is no longer based on literal value of `data-test`, instead it's based on actual status of the button `data-selected` attribute.

Tests in ucc:
https://github.com/splunk/addonfactory-ucc-generator/runs/27207848699
Without fix:
https://github.com/splunk/addonfactory-ucc-generator/runs/26432377281