### PR TITLE
feat: add ability to get console logs

### DIFF
--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -151,6 +151,7 @@ class SeleniumHelper:
     @staticmethod
     def get_local_chrome_opts(headless_run):
         chrome_opts = webdriver.ChromeOptions()
+        chrome_opts.set_capability("goog:loggingPrefs", {"browser": "ALL"})
         chrome_opts.add_argument("--ignore-ssl-errors=yes")
         chrome_opts.add_argument("--ignore-certificate-errors")
         chrome_opts.add_argument("--disable-dev-shm-usage")

--- a/pytest_splunk_addon_ui_smartx/utils.py
+++ b/pytest_splunk_addon_ui_smartx/utils.py
@@ -51,6 +51,8 @@ class LogSource(Enum):
     NETWORK = "network"
     CONSOLE_API = "console-api"
     RECOMMENDATION = "recommendation"
+    SECURITY = "security"
+    INTERVENTION = "intervention"
 
 
 class LogEntry(NamedTuple):

--- a/pytest_splunk_addon_ui_smartx/utils.py
+++ b/pytest_splunk_addon_ui_smartx/utils.py
@@ -33,3 +33,26 @@ def backend_retry(retry_count):
         return retry_method
 
     return backend_retry_decorator
+
+
+def get_browser_logs(browser):
+    """
+    Retrieve browser console logs.
+    This method should be called with a WebDriver instance as an argument.
+
+    :param browser: WebDriver instance
+    :return: List of log entry dictionaries or empty list if not supported/error
+
+    Each log entry dictionary contains:
+    - level: str (e.g., 'INFO', 'DEBUG', 'WARNING', 'SEVERE')
+    - source: str (e.g., 'network', 'console-api')
+    - message: str
+    - timestamp: int
+    """
+    try:
+        if browser.name.lower() == "chrome":
+            return browser.get_log("browser")
+        else:
+            return []
+    except Exception as e:
+        return []

--- a/pytest_splunk_addon_ui_smartx/utils.py
+++ b/pytest_splunk_addon_ui_smartx/utils.py
@@ -50,6 +50,7 @@ class LogLevel(Enum):
 class LogSource(Enum):
     NETWORK = "network"
     CONSOLE_API = "console-api"
+    RECOMMENDATION = "recommendation"
 
 
 class LogEntry(NamedTuple):
@@ -67,26 +68,23 @@ def get_browser_logs(
     """
     Retrieve and optionally filter browser console logs.
     """
-    try:
-        if browser.name.lower() == "chrome":
-            logs = browser.get_log("browser")
-            filtered_logs = []
-
-            for log in logs:
-                entry = LogEntry(
-                    level=LogLevel[log["level"]],
-                    message=log["message"],
-                    source=LogSource(log["source"]),
-                    timestamp=log["timestamp"],
-                )
-
-                if (log_level is None or entry.level == log_level) and (
-                    log_source is None or entry.source == log_source
-                ):
-                    filtered_logs.append(entry)
-
-            return filtered_logs
-        else:
-            return []
-    except Exception as e:
+    if browser.name.lower() != "chrome":
         return []
+
+    logs = browser.get_log("browser")
+    filtered_logs: List[LogEntry] = []
+
+    for log in logs:
+        entry = LogEntry(
+            level=LogLevel[log["level"]],
+            message=log["message"],
+            source=LogSource(log["source"]),
+            timestamp=log["timestamp"],
+        )
+
+        if (log_level is None or entry.level == log_level) and (
+            log_source is None or entry.source == log_source
+        ):
+            filtered_logs.append(entry)
+
+    return filtered_logs

--- a/pytest_splunk_addon_ui_smartx/utils.py
+++ b/pytest_splunk_addon_ui_smartx/utils.py
@@ -80,8 +80,8 @@ def get_browser_logs(
                     timestamp=log["timestamp"],
                 )
 
-                if (log_level is None or entry["level"] == log_level) and (
-                    log_source is None or entry["source"] == log_source
+                if (log_level is None or entry.level == log_level) and (
+                    log_source is None or entry.source == log_source
                 ):
                     filtered_logs.append(entry)
 

--- a/tests/ui/test_splunk_ta_example_addon_input_1.py
+++ b/tests/ui/test_splunk_ta_example_addon_input_1.py
@@ -1,4 +1,5 @@
 from pytest_splunk_addon_ui_smartx.base_test import UccTester
+from pytest_splunk_addon_ui_smartx.utils import get_browser_logs, LogLevel, LogSource
 from .Example_UccLib.account import AccountPage
 from .Example_UccLib.input_page import InputPage
 import pytest
@@ -145,6 +146,15 @@ class TestInput(UccTester):
             r"Field Name is required",
             left_args={"expect_error": True},
         )
+
+        severe_console_logs = get_browser_logs(
+            ucc_smartx_selenium_helper.browser,
+            log_level=LogLevel.SEVERE,
+            log_source=LogSource.CONSOLE_API,
+        )
+        assert (
+            not severe_console_logs
+        ), f"Unexpected severe console logs found: {severe_console_logs}"
 
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.forwarder

--- a/tests/ui/test_splunk_ta_example_addon_input_1.py
+++ b/tests/ui/test_splunk_ta_example_addon_input_1.py
@@ -147,6 +147,16 @@ class TestInput(UccTester):
             left_args={"expect_error": True},
         )
 
+        info_console_logs = get_browser_logs(
+            ucc_smartx_selenium_helper.browser,
+            log_level=LogLevel.INFO,
+            log_source=LogSource.CONSOLE_API,
+        )
+        ucc_framework_logs = [
+            log for log in info_console_logs if "UCC Framework" in log.message
+        ]
+        assert ucc_framework_logs, "No INFO log entry containing 'UCC Framework' found"
+
         severe_console_logs = get_browser_logs(
             ucc_smartx_selenium_helper.browser,
             log_level=LogLevel.SEVERE,

--- a/tests/ui/test_splunk_ta_example_addon_input_1.py
+++ b/tests/ui/test_splunk_ta_example_addon_input_1.py
@@ -1,5 +1,4 @@
 from pytest_splunk_addon_ui_smartx.base_test import UccTester
-from pytest_splunk_addon_ui_smartx.utils import get_browser_logs, LogLevel, LogSource
 from .Example_UccLib.account import AccountPage
 from .Example_UccLib.input_page import InputPage
 import pytest
@@ -146,25 +145,6 @@ class TestInput(UccTester):
             r"Field Name is required",
             left_args={"expect_error": True},
         )
-
-        info_console_logs = get_browser_logs(
-            ucc_smartx_selenium_helper.browser,
-            log_level=LogLevel.INFO,
-            log_source=LogSource.CONSOLE_API,
-        )
-        ucc_framework_logs = [
-            log for log in info_console_logs if "UCC Framework" in log.message
-        ]
-        assert ucc_framework_logs, "No INFO log entry containing 'UCC Framework' found"
-
-        severe_console_logs = get_browser_logs(
-            ucc_smartx_selenium_helper.browser,
-            log_level=LogLevel.SEVERE,
-            log_source=LogSource.CONSOLE_API,
-        )
-        assert (
-            not severe_console_logs
-        ), f"Unexpected severe console logs found: {severe_console_logs}"
 
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.forwarder

--- a/tests/ui/test_splunk_ta_example_addon_logging.py
+++ b/tests/ui/test_splunk_ta_example_addon_logging.py
@@ -44,7 +44,9 @@ class TestLogging(UccTester):
         ucc_framework_logs = [
             log for log in info_console_logs if "UCC Framework" in log.message
         ]
-        assert ucc_framework_logs, "No INFO log entry containing 'UCC Framework' found"
+        assert (
+            len(ucc_framework_logs) > 0
+        ), "No INFO log entry containing 'UCC Framework' found"
 
         severe_console_logs = get_browser_logs(
             ucc_smartx_selenium_helper.browser,
@@ -52,5 +54,5 @@ class TestLogging(UccTester):
             log_source=LogSource.CONSOLE_API,
         )
         assert (
-            not severe_console_logs
+            len(severe_console_logs) == 0
         ), f"Unexpected severe console logs found: {severe_console_logs}"

--- a/tests/ui/test_splunk_ta_example_addon_logging.py
+++ b/tests/ui/test_splunk_ta_example_addon_logging.py
@@ -3,6 +3,8 @@ from pytest_splunk_addon_ui_smartx.pages.logging import Logging
 import pytest
 import random
 
+from pytest_splunk_addon_ui_smartx.utils import LogSource, LogLevel, get_browser_logs
+
 TA_NAME = "Splunk_TA_UCCExample"
 TA_CONF = "splunk_ta_uccexample_settings"
 
@@ -31,4 +33,24 @@ class TestLogging(UccTester):
         level = random.choice(levels)
         logging.log_level.select(level)
         logging.save()
+
         self.assert_util(logging.log_level.get_value().lower(), level.lower())
+
+        info_console_logs = get_browser_logs(
+            ucc_smartx_selenium_helper.browser,
+            log_level=LogLevel.INFO,
+            log_source=LogSource.CONSOLE_API,
+        )
+        ucc_framework_logs = [
+            log for log in info_console_logs if "UCC Framework" in log.message
+        ]
+        assert ucc_framework_logs, "No INFO log entry containing 'UCC Framework' found"
+
+        severe_console_logs = get_browser_logs(
+            ucc_smartx_selenium_helper.browser,
+            log_level=LogLevel.SEVERE,
+            log_source=LogSource.CONSOLE_API,
+        )
+        assert (
+            not severe_console_logs
+        ), f"Unexpected severe console logs found: {severe_console_logs}"


### PR DESCRIPTION
[ADDON-73881](https://splunk.atlassian.net/browse/ADDON-73881)

As a smartx enjoyer, I want to get access to the browser console logs to fail my tests if there are JS errors.

## Changes
- Add capability to track logs in Chrome
- Add a helper to access an array of logs


## Example of usage
```python
        severe_console_logs = get_browser_logs(ucc_smartx_selenium_helper.browser, log_level=LogLevel.SEVERE, log_source=LogSource.CONSOLE_API)
        assert not severe_console_logs, f"Unexpected severe console logs found: {severe_console_logs}"
```

Currently, this feature is only supported with the Chrome browser.
Analysis on adding support for other browser: https://splunk.atlassian.net/browse/ADDON-73881?focusedCommentId=15449369
