### PR TITLE
feat: add an argument to expand moreInfo of an input

### DIFF
--- a/pytest_splunk_addon_ui_smartx/components/table.py
+++ b/pytest_splunk_addon_ui_smartx/components/table.py
@@ -487,15 +487,19 @@ class Table(BaseComponent):
         row_count = self.get_count_title()
         return int(re.search(r"\d+", row_count).group())
 
-    def get_more_info(self, name, cancel=True):
+    def get_more_info(self, name, cancel=True, expand_row=True):
         """
         Returns the text from the more info field within a tables row
             :param name: Str row name
             :param cancel: Bool Whether or not to click cancel after getting the info
+            :param expand_row: Bool which specifies whether to expand `more_info` or not.
             :return: Dict The information found when opening the info table on a row in the table
         """
         _row = self._get_row(name)
-        _row.find_element(*list(self.elements["more_info"]._asdict().values())).click()
+        if expand_row:
+            _row.find_element(
+                *list(self.elements["more_info"]._asdict().values())
+            ).click()
         keys = self.more_info_row.find_elements(
             *list(self.elements["more_info_key"]._asdict().values())
         )

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from selenium.webdriver.common.by import By
+from pytest_splunk_addon_ui_smartx.components.table import Table
+
+@pytest.fixture
+def mock_table():
+    mock_browser = MagicMock()
+    
+    # Mocking container with a `select` attribute
+    mock_container = MagicMock()
+    mock_container.select = "#test-container"
+    table = Table(mock_browser, mock_container)
+    return table
+
+@patch("pytest_splunk_addon_ui_smartx.components.table.Table._get_row")
+def test_get_more_info_expand_row_false(mock_get_row, mock_table):
+    mock_row = MagicMock()
+    mock_get_row.return_value = mock_row
+
+    mock_more_info_element = MagicMock()
+    mock_row.find_element.return_value = mock_more_info_element
+
+    # Calling the function with expand_row=False and cancel=False as we are testing for expand_row parameter
+    mock_table.get_more_info(name="Test Row", cancel=False, expand_row=False)
+
+    mock_get_row.assert_called_with("Test Row")
+    mock_row.find_element.assert_not_called()  
+    mock_more_info_element.click.assert_not_called()
+
+
+@patch("pytest_splunk_addon_ui_smartx.components.table.Table._get_row")
+def test_get_more_info_expand_row_true(mock_get_row, mock_table):
+    mock_row = MagicMock()
+    mock_get_row.return_value = mock_row
+
+    mock_more_info_element = MagicMock()
+    mock_row.find_element.return_value = mock_more_info_element
+
+    mock_key1 = MagicMock()
+    mock_key1.get_attribute.return_value = "  Key1  "  
+    mock_key2 = MagicMock()
+    mock_key2.get_attribute.return_value = "  Key2  "
+
+    mock_value1 = MagicMock()
+    mock_value1.get_attribute.return_value = "  Value1  "
+    mock_value2 = MagicMock()
+    mock_value2.get_attribute.return_value = "  Value2  "
+
+    mock_table.more_info_row.find_elements.side_effect = [
+        [mock_key1, mock_key2],
+        [mock_value1, mock_value2],
+    ]
+    
+    # Call the function with expand_row=True and cancel=False as we are testing for expand_row parameter
+    result = mock_table.get_more_info(name="Test Row", cancel=False, expand_row=True)
+
+    mock_get_row.assert_called_with("Test Row")
+    mock_more_info_element.click.assert_called_once()
+    assert result == {"Key1": "Value1", "Key2": "Value2"}

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -3,15 +3,17 @@ from unittest.mock import MagicMock, patch
 from selenium.webdriver.common.by import By
 from pytest_splunk_addon_ui_smartx.components.table import Table
 
+
 @pytest.fixture
 def mock_table():
     mock_browser = MagicMock()
-    
+
     # Mocking container with a `select` attribute
     mock_container = MagicMock()
     mock_container.select = "#test-container"
     table = Table(mock_browser, mock_container)
     return table
+
 
 @patch("pytest_splunk_addon_ui_smartx.components.table.Table._get_row")
 def test_get_more_info_expand_row_false(mock_get_row, mock_table):
@@ -25,7 +27,7 @@ def test_get_more_info_expand_row_false(mock_get_row, mock_table):
     mock_table.get_more_info(name="Test Row", cancel=False, expand_row=False)
 
     mock_get_row.assert_called_with("Test Row")
-    mock_row.find_element.assert_not_called()  
+    mock_row.find_element.assert_not_called()
     mock_more_info_element.click.assert_not_called()
 
 
@@ -38,7 +40,7 @@ def test_get_more_info_expand_row_true(mock_get_row, mock_table):
     mock_row.find_element.return_value = mock_more_info_element
 
     mock_key1 = MagicMock()
-    mock_key1.get_attribute.return_value = "  Key1  "  
+    mock_key1.get_attribute.return_value = "  Key1  "
     mock_key2 = MagicMock()
     mock_key2.get_attribute.return_value = "  Key2  "
 
@@ -51,7 +53,7 @@ def test_get_more_info_expand_row_true(mock_get_row, mock_table):
         [mock_key1, mock_key2],
         [mock_value1, mock_value2],
     ]
-    
+
     # Call the function with expand_row=True and cancel=False as we are testing for expand_row parameter
     result = mock_table.get_more_info(name="Test Row", cancel=False, expand_row=True)
 


### PR DESCRIPTION
Added an argument in `get_more_info` function which specifies whether to click on the arrow that display more info about an input.
This is required in a scenario as described in https://github.com/splunk/addonfactory-ucc-generator/issues/1410.