### PR TITLE
fix(browser_logs): add log source javascript

### DIFF
--- a/pytest_splunk_addon_ui_smartx/utils.py
+++ b/pytest_splunk_addon_ui_smartx/utils.py
@@ -53,6 +53,7 @@ class LogSource(Enum):
     RECOMMENDATION = "recommendation"
     SECURITY = "security"
     INTERVENTION = "intervention"
+    JAVASCRIPT = "javascript"
 
 
 class LogEntry(NamedTuple):


### PR DESCRIPTION
[The run](https://github.com/splunk/addonfactory-ucc-generator/pull/1445/checks?check_run_id=33318042641) throws the errors of unknown source
`ValueError: 'javascript' is not a valid LogSource`

<details><summary>Full logs</summary>
<p>

```
test_alert_actions_page.chrome_TestAlertActions
  ✅ test_alert_action_save
test_configuration_page_account_tab.chrome_TestAccount
  ❌ test_account_filter_functionality_negative
	ValueError: 'javascript' is not a valid LogSource
  ✅ test_account_edit_valid_title
  ❌ test_account_delete_close_entity
	ValueError: 'javascript' is not a valid LogSource
  ❌ test_account_required_field_example_multiple_select
	ValueError: 'javascript' is not a valid LogSource
  ❌ test_add_account_duplicate_name
	ValueError: 'javascript' is not a valid LogSource
test_configuration_page_custom_tab.chrome_TestCustomPage
  ❌ test_custom_valid_input_test_regex
	ValueError: 'javascript' is not a valid LogSource
  ❌ test_custom_valid_input_test_url
	ValueError: 'javascript' is not a valid LogSource
test_configuration_page_logging_tab.chrome_TestLoggingPage
  ❌ test_logging_selected_log_level_frontend_backend
	ValueError: 'javascript' is not a valid LogSource
test_input_page.chrome_TestInputPage
  ✅ test_inputs_more_info
  ✅ test_example_input_one_list_multiple_select_test
  ✅ test_example_input_one_default_value_example_radio
  ✅ test_example_input_one_edit_cancel_entity
  ❌ test_example_input_two_select_select_value_example_multiple_select
	ValueError: 'javascript' is not a valid LogSource
  ❌ test_example_input_two_required_field_example_radio
	ValueError: 'javascript' is not a valid LogSource
  ❌ test_example_input_two_add_frontend_backend_validation
	ValueError: 'javascript' is not a valid LogSource
  ✅ test_example_input_two_edit_cancel_entity
  ✅ test_example_input_two_clone_cancel_entity
  ✅ test_example_input_two_edit_valid_title
  ✅ test_inputs_disable_all_close
  ✅ test_inputs_textarea_height
  ❌ test_example_inputs_with_valid_interval[0 0,11 2 */2 *]
	ValueError: 'javascript' is not a valid LogSource
  ❌ test_example_inputs_with_valid_interval[* * * * *]
	ValueError: 'javascript' is not a valid LogSource
  ❌ test_example_inputs_with_not_valid_interval[-2]
	ValueError: 'javascript' is not a valid LogSource
```

</p>
</details> 


I assume this PR would fix it