### PR TITLE
fix: use guest mode in chrome

### DIFF
--- a/pytest_splunk_addon_ui_smartx/base_test.py
+++ b/pytest_splunk_addon_ui_smartx/base_test.py
@@ -156,6 +156,7 @@ class SeleniumHelper:
         chrome_opts.add_argument("--ignore-certificate-errors")
         chrome_opts.add_argument("--disable-dev-shm-usage")
         chrome_opts.add_argument("--window-size=1280,768")
+        chrome_opts.add_argument("--guest")
         if headless_run:
             chrome_opts.add_argument("--headless")
         return chrome_opts


### PR DESCRIPTION
This PR fixes the issue where the test execution in chrome were interrupted by unwanted prompts like "Change your password". Using "Guest" mode disables those functionality in chrome.

Ref: https://splunk.atlassian.net/browse/ADDON-81321