### PR TITLE
ci: migrate GH_TOKEN_ADMIN to GitHub App token authentication

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -204,6 +204,13 @@ jobs:
         with:
           submodules: false
           persist-credentials: false
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -218,7 +225,7 @@ jobs:
           extra_plugins: |
             semantic-release-replace-plugin
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
         run: |
           poetry build


### PR DESCRIPTION
## Summary

- Replace the long-lived PAT (`GH_TOKEN_ADMIN`) in the `publish` job with a short-lived GitHub App installation token generated by `actions/create-github-app-token@v3`
- The app token is scoped to the org via `owner: ${{ github.repository_owner }}` and uses the centrally-managed `GH_APP_CLIENT_ID` / `GH_APP_PRIVATE_KEY` secrets
- `GH_TOKEN_ADMIN` is no longer referenced as an authentication mechanism in any workflow

Made with [Cursor](https://cursor.com)