### PR TITLE
fix: recognize breaking-change shorthand in releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -27,9 +27,9 @@
         {
           "parserOpts": {
             "headerPattern": "^(\\w*)(?:\\(([^)]*)\\))?(!)?: (.*)$",
-            "headerCorrespondence": ["type", "scope", "breaking", "subject"]
+            "headerCorrespondence": ["type", "scope", "breakingMarker", "subject"]
           },
-          "releaseRules": [{ "breaking": "!", "release": "major" }]
+          "releaseRules": [{ "breakingMarker": "!", "release": "major" }]
         },
       ],
       [
@@ -72,7 +72,7 @@
         {
           "parserOpts": {
             "headerPattern": "^(\\w*)(?:\\(([^)]*)\\))?(!)?: (.*)$",
-            "headerCorrespondence": ["type", "scope", "breaking", "subject"]
+            "headerCorrespondence": ["type", "scope", "breakingMarker", "subject"]
           }
         },
       ],

--- a/.releaserc
+++ b/.releaserc
@@ -22,7 +22,16 @@
     ],
   plugins:
     [
-      "@semantic-release/commit-analyzer",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "parserOpts": {
+            "headerPattern": "^(\\w*)(?:\\(([^)]*)\\))?(!)?: (.*)$",
+            "headerCorrespondence": ["type", "scope", "breaking", "subject"]
+          },
+          "releaseRules": [{ "breaking": "!", "release": "major" }]
+        },
+      ],
       [
         "semantic-release-replace-plugin",
         {
@@ -58,7 +67,15 @@
           ]
         }
       ],
-      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "parserOpts": {
+            "headerPattern": "^(\\w*)(?:\\(([^)]*)\\))?(!)?: (.*)$",
+            "headerCorrespondence": ["type", "scope", "breaking", "subject"]
+          }
+        },
+      ],
       [
         "@semantic-release/exec",
         {


### PR DESCRIPTION
## Summary

- extend the Angular commit parser to recognize the Conventional Commits `!` breaking-change marker
- classify commits carrying that marker as major releases
- apply the same header parsing to generated release notes

## Root cause

The previous squash commit used `feat!:` but the default Angular parser did not recognize that header. Its PR body used a Markdown “Breaking change” heading rather than the exact semantic-release footer, so commit analysis returned no release.

## Validation

- `.releaserc` parses successfully as YAML
- `git diff --check`
- `@semantic-release/commit-analyzer@13` classifies the exact footer-less `feat!:` case as `major`

BREAKING CHANGE: Python versions outside 3.10 through 3.13 are no longer supported.
